### PR TITLE
feat: add more CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint": "echo 'No linter configured yet' && exit 0"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "dependencies": {
     "@clack/prompts": "^0.8.0",


### PR DESCRIPTION
## What

Harden CI with Node version matrix (18, 20, 22), CLI smoke test, and runtime dependency audit.

## Why

We declare engines: >=18 but only tested on Node 20. No CI step verified that the CLI binary actually runs, and no security audit was in place.

## How I tested

- [ ] `npm test` passes
- [ ] Tested against a real repo: <!-- which one? -->
- [ ] `--dry-run` output looks correct (if applicable)

## Checklist

- [ ] Changes are focused on a single feature or fix
- [ ] Tests added or updated for any logic changes
- [ ] No new dependencies added (or justified in the PR description)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now runs tests across Node.js 20 and 22.
  * CI includes a quick CLI help check and an automated dependency security audit.
  * Minimum supported Node.js runtime bumped to ≥20 in project configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->