### PR TITLE
Add .php as code bearing extension

### DIFF
--- a/src/lib/diff-classifier.js
+++ b/src/lib/diff-classifier.js
@@ -28,7 +28,7 @@ export const LOCK_FILES = new Set([
  */
 const CODE_BEARING_EXTS = new Set([
   '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs',
-  '.py', '.go', '.rs', '.rb', '.java', '.kt', '.swift',
+  '.py', '.go', '.rs', '.rb', '.java', '.kt', '.swift', '.php'
 ]);
 
 /**

--- a/tests/diff-classifier.test.js
+++ b/tests/diff-classifier.test.js
@@ -33,7 +33,7 @@ describe('diff-classifier', () => {
     });
 
     it('returns false for a single code-bearing file', () => {
-      const exts = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.py', '.go', '.rs', '.rb', '.java', '.kt', '.swift'];
+      const exts = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.py', '.go', '.rs', '.rb', '.java', '.kt', '.swift', '.php'];
       for (const ext of exts) {
         expect(isNoOpDiff([`src/file${ext}`])).toBe(false);
       }


### PR DESCRIPTION
## What

Add '.php' as a code bearing extension.

## Why

Php file changes were not being recognized as code bearing resulting in them being ignored when running doc sync. 
'composer.lock' is present in the lock files so it was likely forgotten.

## How I tested

- [x] `npm test` passes
- [x] Tested against a real repo
- [x] `--dry-run` output looks correct (if applicable)

## Checklist

- [x] Changes are focused on a single feature or fix
- [x] Tests added or updated for any logic changes
- [x] No new dependencies added (or justified in the PR description)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PHP file changes are now correctly recognized as meaningful code changes rather than no-op updates.
* **Tests**
  * Expanded coverage to verify correct classification of PHP-only changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->