### PR TITLE
fix: preserve hand-written CLAUDE.md lines and normalize skill paths on Windows

### DIFF
--- a/src/commands/customize.js
+++ b/src/commands/customize.js
@@ -213,7 +213,7 @@ function findAgents(agentsDir, repoPath) {
         const nameMatch = content.match(/name:\s*(.+)/);
         agents.push({
           name: nameMatch ? nameMatch[1].trim() : entry.replace('.md', ''),
-          relativePath: relative(repoPath, full),
+          relativePath: relativePosix(repoPath, full),
           content,
         });
       }
@@ -250,7 +250,7 @@ function gatherProjectContext(repoPath) {
           walkSkills(full);
         } else if (entry.endsWith('.md')) {
           const content = readFileSync(full, 'utf8');
-          const relativePath = relative(repoPath, full);
+          const relativePath = relativePosix(repoPath, full);
           parts.push(`### ${relativePath}\n\`\`\`\n${content}\n\`\`\``);
         }
       }

--- a/src/commands/doc-init.js
+++ b/src/commands/doc-init.js
@@ -1,4 +1,4 @@
-import { resolve, join, dirname, relative } from 'path';
+import { resolve, join, dirname } from 'path';
 import { existsSync, readFileSync, writeFileSync, copyFileSync, mkdirSync, chmodSync, readdirSync } from 'fs';
 import { fileURLToPath } from 'url';
 import pc from 'picocolors';
@@ -10,6 +10,7 @@ import { writeSkillFiles, writeTransformedFiles, extractRulesFromSkills, generat
 import { persistGraphArtifacts } from '../lib/graph-persistence.js';
 import { installGitHook } from '../lib/git-hook.js';
 import { CliError } from '../lib/errors.js';
+import { toPosixRelative } from '../lib/posix-path.js';
 import { resolveTimeout } from '../lib/timeout.js';
 import { TARGETS, resolveTarget, getAllowedPaths, writeConfig, loadConfig, mergeConfiguredTargets } from '../lib/target.js';
 import { detectAvailableBackends, resolveBackend } from '../lib/backend.js';
@@ -924,12 +925,6 @@ function ensureRecommendedAgentGitignore(repoPath, summaryLines) {
     writeFileSync(gitignorePath, `${entry}\n`, 'utf8');
   }
   summaryLines.push(`${pc.green('+')} .gitignore (dev/)`);
-}
-
-function toPosixRelative(from, to) {
-  const rel = relative(from, to);
-  if (!rel || rel === '.') return '';
-  return rel.split('\\').join('/');
 }
 
 function showTokenSummary(startTime) {

--- a/src/commands/doc-sync.js
+++ b/src/commands/doc-sync.js
@@ -182,7 +182,6 @@ function flattenPublishedMap(perTarget) {
 export async function docSyncCommand(path, options) {
   const repoPath = resolve(path);
   const gitRoot = getGitRoot(repoPath);
-  const projectPrefix = toPosixRelative(gitRoot, repoPath);
   const verbose = !!options.verbose;
   const commits = typeof options.commits === 'number' ? options.commits : 1;
 
@@ -217,6 +216,9 @@ export async function docSyncCommand(path, options) {
   if (!gitRoot || !isGitRepo(repoPath)) {
     throw new CliError('Not a git repository. doc sync requires git history.');
   }
+
+  // Safe only past the gitRoot guard above: relative() throws on a null root.
+  const projectPrefix = toPosixRelative(gitRoot, repoPath);
 
   if (!existsSync(skillsDir)) {
     throw new CliError(`No ${sourceTarget.skillsDir || '.claude/skills'}/ found. Run aspens doc init first.`);

--- a/src/commands/doc-sync.js
+++ b/src/commands/doc-sync.js
@@ -1,4 +1,4 @@
-import { resolve, join, relative, dirname } from 'path';
+import { resolve, join, dirname } from 'path';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import pc from 'picocolors';
 import * as p from '@clack/prompts';
@@ -10,6 +10,7 @@ import { persistGraphArtifacts, loadGraph, extractSubgraph, formatNavigationCont
 import { findSkillFiles, parseActivationPatterns, getActivationBlock, fileMatchesActivation } from '../lib/skill-reader.js';
 import { buildDomainContext, buildBaseContext } from '../lib/context-builder.js';
 import { CliError } from '../lib/errors.js';
+import { relativePosix, toPosixRelative } from '../lib/posix-path.js';
 import { resolveTimeout } from '../lib/timeout.js';
 import { installGitHook, removeGitHook } from '../lib/git-hook.js';
 import { isGitRepo, getGitRoot, getGitDiff, getGitLog, getChangedFiles } from '../lib/git-helpers.js';
@@ -181,7 +182,7 @@ function flattenPublishedMap(perTarget) {
 export async function docSyncCommand(path, options) {
   const repoPath = resolve(path);
   const gitRoot = getGitRoot(repoPath);
-  const projectPrefix = toGitRelative(gitRoot, repoPath);
+  const projectPrefix = toPosixRelative(gitRoot, repoPath);
   const verbose = !!options.verbose;
   const commits = typeof options.commits === 'number' ? options.commits : 1;
 
@@ -531,13 +532,6 @@ ${truncate(instructionsContent, 5000)}
   p.outro(`${results.length} file(s) updated`);
 }
 
-function toGitRelative(gitRoot, repoPath) {
-  if (!gitRoot) return '';
-  const rel = relative(gitRoot, repoPath);
-  if (!rel || rel === '.') return '';
-  return rel.split('\\').join('/');
-}
-
 function withProjectPrefix(file, projectPrefix) {
   return projectPrefix ? `${projectPrefix}/${file}` : file;
 }
@@ -558,7 +552,7 @@ function findExistingSkills(repoPath, target) {
   const fullDir = join(repoPath, sd);
   return findSkillFiles(fullDir, { skillFilename: sf }).map(s => ({
     name: s.name,
-    path: relative(repoPath, s.path),
+    path: relativePosix(repoPath, s.path),
     content: s.content,
   }));
 }

--- a/src/lib/frameworks/nextjs.js
+++ b/src/lib/frameworks/nextjs.js
@@ -13,7 +13,8 @@
  */
 
 import { existsSync, readdirSync, statSync } from 'fs';
-import { join, basename, extname, relative } from 'path';
+import { join, basename, extname } from 'path';
+import { relativePosix } from '../posix-path.js';
 
 const APP_ROUTER_FILE_NAMES = new Set([
   'page', 'layout', 'route', 'loading', 'error',
@@ -80,7 +81,7 @@ export function detectNextjsEntryPoints(repoPath) {
         const full = dir ? join(repoPath, dir, name + ext) : join(repoPath, name + ext);
         if (existsSync(full) && safeIsFile(full)) {
           found.push({
-            path: relative(repoPath, full),
+            path: relativePosix(repoPath, full),
             kind: 'nextjs-middleware',
           });
         }
@@ -112,7 +113,7 @@ function walkAppDir(repoPath, dir, out, depth = 0) {
 
     const stem = basename(entry, ext);
     if (APP_ROUTER_FILE_NAMES.has(stem) || METADATA_ROUTE_NAMES.has(stem)) {
-      out.push({ path: relative(repoPath, full), kind: 'nextjs-app' });
+      out.push({ path: relativePosix(repoPath, full), kind: 'nextjs-app' });
     }
   }
 }
@@ -137,7 +138,7 @@ function walkPagesDir(repoPath, dir, out, depth = 0) {
     const ext = extname(entry);
     if (!CODE_EXTS.has(ext)) continue;
 
-    out.push({ path: relative(repoPath, full), kind: 'nextjs-pages' });
+    out.push({ path: relativePosix(repoPath, full), kind: 'nextjs-pages' });
   }
 }
 

--- a/src/lib/git-hook.js
+++ b/src/lib/git-hook.js
@@ -1,8 +1,9 @@
-import { join, relative } from 'path';
+import { join } from 'path';
 import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync, chmodSync } from 'fs';
 import { execSync } from 'child_process';
 import pc from 'picocolors';
 import { CliError } from './errors.js';
+import { toPosixRelative } from './posix-path.js';
 import { getGitRoot } from './git-helpers.js';
 
 function resolveAspensPath() {
@@ -148,12 +149,6 @@ export function removeGitHook(repoPath) {
     console.log(pc.dim('  Re-install first: aspens doc sync --install-hook'));
     console.log(pc.dim('  Or edit manually: .git/hooks/post-commit\n'));
   }
-}
-
-function toPosixRelative(from, to) {
-  const rel = relative(from, to);
-  if (!rel || rel === '.') return '';
-  return rel.split('\\').join('/');
 }
 
 function escapeForSingleQuotes(value) {

--- a/src/lib/graph-builder.js
+++ b/src/lib/graph-builder.js
@@ -1,5 +1,5 @@
 import { readFileSync, existsSync, readdirSync, statSync } from 'fs';
-import { join, basename, extname, relative, dirname, resolve } from 'path';
+import { join, basename, extname, dirname, resolve } from 'path';
 import { execSync } from 'child_process';
 import { detectEntryPoints, scanRepo } from './scanner.js';
 import { LOCK_FILES } from './diff-classifier.js';
@@ -7,6 +7,7 @@ import { parseJsImports } from './parsers/typescript.js';
 import { parsePyImports, extractPythonExports } from './parsers/python.js';
 import { detectNextjsEntryPoints, isNextjsProject, nextjsImplicitAliases } from './frameworks/nextjs.js';
 import { loadPathAliases, resolveAliasImport } from './path-resolver.js';
+import { relativePosix } from './posix-path.js';
 
 /**
  * Build the import graph for a repository.
@@ -43,7 +44,7 @@ export async function buildRepoGraph(repoPath, languages = []) {
   const edges = [];
 
   for (const absPath of filePaths) {
-    const relPath = relative(repoPath, absPath);
+    const relPath = relativePosix(repoPath, absPath);
     const content = readFileSafe(absPath);
     if (content === null) continue;
 
@@ -300,7 +301,7 @@ function isPythonRelativeImport(specifier) {
 function resolveRelativeImport(repoPath, fromFile, specifier) {
   const fromDir = dirname(join(repoPath, fromFile));
   const targetBase = resolve(fromDir, specifier);
-  const targetRel = relative(repoPath, targetBase);
+  const targetRel = relativePosix(repoPath, targetBase);
 
   // If the specifier already has an extension, check directly
   if (extname(specifier)) {
@@ -315,7 +316,7 @@ function resolveRelativeImport(repoPath, fromFile, specifier) {
   for (const ext of extensions) {
     const candidate = targetBase + ext;
     if (existsSync(candidate)) {
-      return relative(repoPath, candidate);
+      return relativePosix(repoPath, candidate);
     }
   }
 
@@ -324,7 +325,7 @@ function resolveRelativeImport(repoPath, fromFile, specifier) {
   for (const ext of indexExts) {
     const candidate = join(targetBase, 'index' + ext);
     if (existsSync(candidate)) {
-      return relative(repoPath, candidate);
+      return relativePosix(repoPath, candidate);
     }
   }
 
@@ -354,7 +355,7 @@ function resolvePythonRelativeImport(repoPath, fromFile, specifier) {
     // Just dots — importing the package itself (__init__.py)
     const initPath = join(baseDir, '__init__.py');
     if (existsSync(initPath)) {
-      return relative(repoPath, initPath);
+      return relativePosix(repoPath, initPath);
     }
     return null;
   }
@@ -366,13 +367,13 @@ function resolvePythonRelativeImport(repoPath, fromFile, specifier) {
   // Try as a .py file
   const pyFile = modulePath + '.py';
   if (existsSync(pyFile)) {
-    return relative(repoPath, pyFile);
+    return relativePosix(repoPath, pyFile);
   }
 
   // Try as a package (__init__.py)
   const initFile = join(modulePath, '__init__.py');
   if (existsSync(initFile)) {
-    return relative(repoPath, initFile);
+    return relativePosix(repoPath, initFile);
   }
 
   return null;
@@ -394,13 +395,13 @@ function resolvePythonAbsoluteImport(repoPath, specifier, pythonRoots = [repoPat
     // Try as a .py file
     const pyFile = modulePath + '.py';
     if (existsSync(pyFile)) {
-      return relative(repoPath, pyFile);
+      return relativePosix(repoPath, pyFile);
     }
 
     // Try as a package (__init__.py)
     const initFile = join(modulePath, '__init__.py');
     if (existsSync(initFile)) {
-      return relative(repoPath, initFile);
+      return relativePosix(repoPath, initFile);
     }
   }
 

--- a/src/lib/impact.js
+++ b/src/lib/impact.js
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
-import { join, extname, relative } from 'path';
+import { join, extname } from 'path';
+import { relativePosix, toPosixRelative } from './posix-path.js';
 import { scanRepo } from './scanner.js';
 import { buildRepoGraph } from './graph-builder.js';
 import { loadConfig, TARGETS } from './target.js';
@@ -769,12 +770,6 @@ function commandToHookPath(command, repoPath) {
   return join(repoPath, ...match[1].split('/'));
 }
 
-function toPosixRelative(from, to) {
-  const rel = relative(from, to);
-  if (!rel || rel === '.') return '';
-  return rel.split('\\').join('/');
-}
-
 function inferTargetsFromScan(scan) {
   const targets = [];
   if (scan.hasClaudeConfig || scan.hasClaudeMd) targets.push('claude');
@@ -907,7 +902,7 @@ function collectSourceState(repoPath) {
 
       if (!SOURCE_EXTS.has(extname(entry))) continue;
 
-      const relPath = relative(repoPath, full);
+      const relPath = relativePosix(repoPath, full);
       files.push({ path: relPath, mtimeMs: stat.mtimeMs });
       if (stat.mtimeMs > newestSourceMtime) {
         newestSourceMtime = stat.mtimeMs;

--- a/src/lib/path-resolver.js
+++ b/src/lib/path-resolver.js
@@ -12,6 +12,7 @@
 
 import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
 import { join, dirname, extname, resolve, relative } from 'path';
+import { relativePosix } from './posix-path.js';
 
 const ALIAS_RESOLUTION_EXTS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'];
 const ALIAS_INDEX_EXTS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'];
@@ -155,7 +156,7 @@ export function resolveAliasImport(repoPath, specifier, aliases) {
 
     if (extname(rest)) {
       if (existsSync(targetBase) && isInsideRepo(repoPath, targetBase)) {
-        return relative(repoPath, targetBase);
+        return relativePosix(repoPath, targetBase);
       }
       continue;
     }
@@ -163,14 +164,14 @@ export function resolveAliasImport(repoPath, specifier, aliases) {
     for (const ext of ALIAS_RESOLUTION_EXTS) {
       const candidate = targetBase + ext;
       if (existsSync(candidate) && isInsideRepo(repoPath, candidate)) {
-        return relative(repoPath, candidate);
+        return relativePosix(repoPath, candidate);
       }
     }
 
     for (const ext of ALIAS_INDEX_EXTS) {
       const candidate = join(targetBase, 'index' + ext);
       if (existsSync(candidate) && isInsideRepo(repoPath, candidate)) {
-        return relative(repoPath, candidate);
+        return relativePosix(repoPath, candidate);
       }
     }
   }

--- a/src/lib/posix-path.js
+++ b/src/lib/posix-path.js
@@ -1,0 +1,14 @@
+import { relative } from 'path';
+
+export function toPosix(filePath) {
+  return typeof filePath === 'string' ? filePath.split('\\').join('/') : filePath;
+}
+
+export function relativePosix(from, to) {
+  return toPosix(relative(from, to));
+}
+
+export function toPosixRelative(from, to) {
+  const rel = relativePosix(from, to);
+  return !rel || rel === '.' ? '' : rel;
+}

--- a/src/lib/scanner.js
+++ b/src/lib/scanner.js
@@ -1,6 +1,7 @@
 import { readFileSync, existsSync, readdirSync, statSync } from 'fs';
-import { join, basename, extname, relative } from 'path';
+import { join, basename, extname } from 'path';
 import { SOURCE_EXTS } from './source-exts.js';
+import { relativePosix, toPosix } from './posix-path.js';
 
 /**
  * Scan a repository and return its tech stack, structure, and domains.
@@ -51,7 +52,7 @@ function mergeExtraDomains(result, repoPath, extraDomains) {
       const modules = collectModules(matchedDir, 3);
       result.domains.push({
         name,
-        directories: [relative(repoPath, matchedDir)],
+        directories: [relativePosix(repoPath, matchedDir)],
         modules,
         files: [],
         userSpecified: true,
@@ -308,7 +309,7 @@ function detectStructure(repoPath) {
 
     for (const [key, patterns] of Object.entries(keyPatterns)) {
       const match = srcDirs.find(d => patterns.includes(d.toLowerCase()));
-      if (match) structure.keyDirs[key] = join(structure.srcDir || '.', match);
+      if (match) structure.keyDirs[key] = toPosix(join(structure.srcDir || '.', match));
     }
   }
 
@@ -354,7 +355,7 @@ function detectDomains(repoPath) {
       if (root === repoPath && entry === nestedChild) continue;
 
       const full = join(root, entry);
-      const relDir = relative(repoPath, full);
+      const relDir = relativePosix(repoPath, full);
       if (seen.has(relDir)) continue;
       seen.add(relDir);
 

--- a/src/lib/target-transform.js
+++ b/src/lib/target-transform.js
@@ -5,11 +5,12 @@
  * Other targets are projected from that canonical output.
  */
 
-import { join, relative } from 'path';
+import { join } from 'path';
 import { readFileSync } from 'fs';
 import { TARGETS } from './target.js';
 import { CliError } from './errors.js';
 import { findSkillFiles } from './skill-reader.js';
+import { toPosix, relativePosix } from './posix-path.js';
 
 export function transformForTarget(files, sourceTarget, destTarget, context) {
   if (sourceTarget.id === destTarget.id) return files;
@@ -82,7 +83,7 @@ function transformToDirectoryScoped(files, sourceTarget, destTarget, context) {
 
   if (baseSkill) {
     result.push({
-      path: join(destTarget.skillsDir, 'base', destTarget.skillFilename),
+      path: toPosix(join(destTarget.skillsDir, 'base', destTarget.skillFilename)),
       content: remapContentPaths(baseSkill.content, sourceTarget, destTarget),
     });
   }
@@ -92,7 +93,7 @@ function transformToDirectoryScoped(files, sourceTarget, destTarget, context) {
     if (!domainName) continue;
 
     result.push({
-      path: join(destTarget.skillsDir, domainName, destTarget.skillFilename),
+      path: toPosix(join(destTarget.skillsDir, domainName, destTarget.skillFilename)),
       content: remapContentPaths(skill.content, sourceTarget, destTarget),
     });
 
@@ -100,7 +101,7 @@ function transformToDirectoryScoped(files, sourceTarget, destTarget, context) {
     if (!targetDir) continue;
 
     result.push({
-      path: join(targetDir, destTarget.directoryDocFile || 'AGENTS.md'),
+      path: toPosix(join(targetDir, destTarget.directoryDocFile || 'AGENTS.md')),
       content: transformDomainSkill(skill.content, sourceTarget, destTarget),
     });
   }
@@ -133,7 +134,7 @@ function collectSkillsForList(files, pendingBaseSkill, instructionsFile, sourceT
       const skillsDirAbs = join(repoPath, sourceTarget.skillsDir);
       const onDisk = findSkillFiles(skillsDirAbs, { skillFilename: sourceTarget.skillFilename });
       for (const skill of onDisk) {
-        const relPath = relative(repoPath, skill.path).split('\\').join('/');
+        const relPath = relativePosix(repoPath, skill.path);
         merged.set(relPath, { path: relPath, content: skill.content });
       }
     } catch { /* skills dir unreadable — fall through to pending-only */ }
@@ -166,8 +167,8 @@ function collectSkillsForList(files, pendingBaseSkill, instructionsFile, sourceT
 function generateCodexSkillReferences(destTarget, graphSerialized) {
   const files = [];
   const skillsDir = destTarget.skillsDir;
-  const archSkillPath = join(skillsDir, 'architecture', 'SKILL.md');
-  const archRefPath = join(skillsDir, 'architecture', 'references', 'code-map.md');
+  const archSkillPath = toPosix(join(skillsDir, 'architecture', 'SKILL.md'));
+  const archRefPath = toPosix(join(skillsDir, 'architecture', 'references', 'code-map.md'));
 
   files.push({
     path: archSkillPath,
@@ -277,24 +278,78 @@ const BEHAVIOR_RULES = [
   '- **Surgical changes** — Touch only what the task requires. Don\'t refactor adjacent code, fix unrelated formatting, or "improve" things that aren\'t broken.',
 ];
 
+const BEHAVIOR_RULE_LABELS = new Set(
+  BEHAVIOR_RULES.map(ruleLabel).filter(Boolean)
+);
+
+function ruleLabel(line) {
+  const match = line.match(/^\s*-\s+\*\*(.+?)\*\*/);
+  return match ? match[1].trim() : null;
+}
+
+function detectEol(content) {
+  const newlines = content.match(/\r?\n/g) || [];
+  const crlf = newlines.filter(nl => nl === '\r\n').length;
+  return crlf > newlines.length - crlf ? '\r\n' : '\n';
+}
+
+function sectionBodyLines(match) {
+  return match.split('\n').slice(1);
+}
+
+function trailingBlankLines(bodyLines) {
+  const trailing = [];
+  for (let i = bodyLines.length - 1; i >= 0 && !bodyLines[i].trim(); i -= 1) trailing.unshift(bodyLines[i]);
+  return trailing;
+}
+
+function renderMergedSection(heading, canonicalLines, bodyLines, isManaged, eol, atEndOfFile) {
+  const cr = eol === '\r\n' ? '\r' : '';
+  const preserved = [];
+  for (const line of bodyLines) {
+    if (isManaged(line)) continue;
+    if (!line.trim()) {
+      if (preserved.length > 0 && preserved[preserved.length - 1].trim() !== '') preserved.push(cr);
+      continue;
+    }
+    preserved.push(line);
+  }
+  while (preserved.length > 0 && preserved[preserved.length - 1].trim() === '') preserved.pop();
+
+  const lines = [heading + cr, cr, ...canonicalLines.map(line => line + cr), ...preserved];
+  if (atEndOfFile) return lines.concat(trailingBlankLines(bodyLines)).join('\n');
+  return lines.join('\n') + '\n';
+}
+
 /**
  * Deterministically inject/replace the `## Behavior` section in a root instructions
  * file so the same coding guardrails ship with every generated CLAUDE.md/AGENTS.md.
  */
 export function syncBehaviorSection(content) {
   if (!content) return content;
-  const section = ['## Behavior', '', ...BEHAVIOR_RULES].join('\n');
+  const eol = detectEol(content);
   if (/## Behavior\s*\n/i.test(content)) {
-    return content.replace(/## Behavior\s*\n[\s\S]*?(?=\n## |\n\*\*Last Updated|$)/, section + '\n');
+    return content.replace(
+      /## Behavior\s*\n[\s\S]*?(?=\r?\n## |\r?\n\*\*Last Updated|$)/,
+      (match, offset, whole) => renderMergedSection(
+        '## Behavior',
+        BEHAVIOR_RULES,
+        sectionBodyLines(match),
+        line => BEHAVIOR_RULE_LABELS.has(ruleLabel(line)),
+        eol,
+        offset + match.length === whole.length
+      )
+    );
   }
 
+  const section = ['## Behavior', '', ...BEHAVIOR_RULES].join(eol);
   const lastUpdatedMatch = content.match(/\n\*\*Last Updated[^\n]*/);
   if (lastUpdatedMatch) {
     const idx = lastUpdatedMatch.index;
-    return content.slice(0, idx).trimEnd() + '\n\n' + section + '\n' + content.slice(idx);
+    return content.slice(0, idx).trimEnd() + eol + eol + section + eol + content.slice(idx);
   }
 
-  return content.trimEnd() + '\n\n' + section + '\n';
+  return content.trimEnd() + eol + eol + section + eol;
 }
 
 /**
@@ -310,16 +365,28 @@ export function syncSkillsSection(content, baseSkill, domainSkills, destTarget, 
   const skillRefs = buildSkillRefs(baseSkill, domainSkills, destTarget, hasArchitectureSkill);
   if (skillRefs.length === 0) return content;
 
+  const eol = detectEol(content);
+
   // Strip Skill-variant headings the LLM may emit as a workaround for the
   // "do not emit ## Skills" rule (e.g., ## Skills Reference, ## Skills Overview).
   // The canonical `## Skills` (no trailing words) is preserved and handled below.
   let working = content
     .replace(/\n## Skills [^\n]+\r?\n[\s\S]*?(?=\r?\n## |\r?\n\*\*Last Updated|$)/gi, '\n')
-    .replace(/(\r?\n){3,}/g, '\n\n');
+    .replace(/(?:\r?\n){3,}/g, eol + eol);
 
-  const section = ['## Skills', '', ...skillRefs].join('\n');
+  const section = ['## Skills', '', ...skillRefs].join(eol);
   if (/## Skills\s*\n/i.test(working)) {
-    return working.replace(/## Skills\s*\n[\s\S]*?(?=\n## |\n\*\*Last Updated|$)/, section + '\n');
+    return working.replace(
+      /## Skills\s*\n[\s\S]*?(?=\r?\n## |\r?\n\*\*Last Updated|$)/,
+      (match, offset, whole) => renderMergedSection(
+        '## Skills',
+        skillRefs,
+        sectionBodyLines(match),
+        isGeneratedSkillRef,
+        eol,
+        offset + match.length === whole.length
+      )
+    );
   }
 
   // Fresh insert: place the Skills section just BEFORE the first existing
@@ -331,18 +398,34 @@ export function syncSkillsSection(content, baseSkill, domainSkills, destTarget, 
     const idx = nextSectionMatch.index; // index of the '\n' before the heading
     const head = working.slice(0, idx).replace(/\s+$/, '');
     const tail = working.slice(idx).replace(/^\s+/, '');
-    return head + '\n\n' + section + '\n\n' + tail + (working.endsWith('\n') ? '' : '');
+    return head + eol + eol + section + eol + eol + tail + (working.endsWith('\n') ? '' : '');
   }
 
   // No other `## ` heading: append at the end so we don't trap any prose.
-  return working.replace(/\s+$/, '') + '\n\n' + section + '\n';
+  return working.replace(/\s+$/, '') + eol + eol + section + eol;
+}
+
+const SKILLS_DIR_PREFIXES = Array.from(
+  new Set(
+    Object.values(TARGETS)
+      .map(t => t.skillsDir)
+      .filter(Boolean)
+      .map(dir => dir.replace(/\\/g, '/').replace(/\/$/, '') + '/')
+  )
+);
+
+function isGeneratedSkillRef(line) {
+  const match = line.match(/^\s*-\s+`([^`]+)`/);
+  if (!match) return false;
+  const path = match[1].replace(/\\/g, '/');
+  return SKILLS_DIR_PREFIXES.some(prefix => path.startsWith(prefix));
 }
 
 function buildSkillRefs(baseSkill, domainSkills, destTarget, hasArchitectureSkill = false) {
   const refs = [];
 
   if (baseSkill) {
-    refs.push('- `' + join(destTarget.skillsDir, 'base', destTarget.skillFilename) + '` — Base repo skill; load whenever working in this repo.');
+    refs.push('- `' + toPosix(join(destTarget.skillsDir, 'base', destTarget.skillFilename)) + '` — Base repo skill; load whenever working in this repo.');
   }
 
   for (const skill of domainSkills) {
@@ -350,11 +433,11 @@ function buildSkillRefs(baseSkill, domainSkills, destTarget, hasArchitectureSkil
     if (!domainName) continue;
     const description = extractFrontmatterField(skill.content, 'description');
     const suffix = description ? ' — ' + description : '';
-    refs.push('- `' + join(destTarget.skillsDir, domainName, destTarget.skillFilename) + '`' + suffix);
+    refs.push('- `' + toPosix(join(destTarget.skillsDir, domainName, destTarget.skillFilename)) + '`' + suffix);
   }
 
   if (hasArchitectureSkill) {
-    refs.push('- `' + join(destTarget.skillsDir, 'architecture', destTarget.skillFilename) + '` — Import graph and code-map reference for structural changes.');
+    refs.push('- `' + toPosix(join(destTarget.skillsDir, 'architecture', destTarget.skillFilename)) + '` — Import graph and code-map reference for structural changes.');
   }
   return refs;
 }
@@ -469,7 +552,7 @@ export function projectCodexDomainDocs(files, target, scanResult) {
     if (!targetDir) continue;
 
     projected.push({
-      path: join(targetDir, target.directoryDocFile),
+      path: toPosix(join(targetDir, target.directoryDocFile)),
       content: transformDomainSkill(file.content, target, target),
     });
   }
@@ -653,7 +736,7 @@ function extractDomainName(skillPath, target) {
 // second-to-last path segment regardless of whether the source is
 // Claude (`.claude/skills/...`) or Codex (`.agents/skills/...`).
 function extractDomainFromAnyPath(skillPath) {
-  const parts = skillPath.split('/').filter(Boolean);
+  const parts = toPosix(skillPath).split('/').filter(Boolean);
   return parts.length >= 2 ? parts[parts.length - 2] : null;
 }
 
@@ -703,7 +786,7 @@ export function transformPathForTarget(targetId, claudePath) {
     const parts = rest.split('/');
     if (parts.length >= 2) {
       const domain = parts[0];
-      return join(dest.skillsDir, domain, dest.skillFilename);
+      return toPosix(join(dest.skillsDir, domain, dest.skillFilename));
     }
   }
 

--- a/src/lib/target-transform.js
+++ b/src/lib/target-transform.js
@@ -414,11 +414,27 @@ const SKILLS_DIR_PREFIXES = Array.from(
   )
 );
 
+const SKILL_FILENAMES = new Set(
+  Object.values(TARGETS)
+    .map(t => t.skillFilename)
+    .filter(Boolean)
+);
+
+/**
+ * True only for a bullet that points at a generated skill entry point
+ * (`<skillsDir>/<name>/<skillFilename>`). Deeper or differently named paths
+ * under a skills dir are hand-written references (e.g.
+ * `.claude/skills/base/reference/api.md`), so they are preserved instead of
+ * being dropped as stale generated output.
+ */
 function isGeneratedSkillRef(line) {
   const match = line.match(/^\s*-\s+`([^`]+)`/);
   if (!match) return false;
-  const path = match[1].replace(/\\/g, '/');
-  return SKILLS_DIR_PREFIXES.some(prefix => path.startsWith(prefix));
+  const path = toPosix(match[1]);
+  const prefix = SKILLS_DIR_PREFIXES.find(dir => path.startsWith(dir));
+  if (!prefix) return false;
+  const segments = path.slice(prefix.length).split('/');
+  return segments.length === 2 && SKILL_FILENAMES.has(segments[1]);
 }
 
 function buildSkillRefs(baseSkill, domainSkills, destTarget, hasArchitectureSkill = false) {

--- a/src/templates/hooks/save-tokens.mjs
+++ b/src/templates/hooks/save-tokens.mjs
@@ -2,6 +2,8 @@ import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync, unlink
 import { join, resolve, relative } from 'path';
 import { fileURLToPath } from 'url';
 
+const toPosix = (p) => p.split('\\').join('/');
+
 const DEFAULT_CONFIG = {
   enabled: true,
   warnAtTokens: 175000,
@@ -100,7 +102,7 @@ export function saveHandoff(projectDir, input = {}, reason = 'limit') {
 
   const now = new Date();
   const stamp = now.toISOString().replace(/[:.]/g, '-');
-  const relativePath = join('.aspens', 'sessions', `${stamp}-claude-handoff.md`);
+  const relativePath = toPosix(join('.aspens', 'sessions', `${stamp}-claude-handoff.md`));
   const handoffPath = join(projectDir, relativePath);
   const snapshot = sessionTokenSnapshot(projectDir, input);
   const tokenCount = Number.isInteger(snapshot.tokens) ? snapshot.tokens : null;
@@ -175,7 +177,7 @@ export function latestHandoff(projectDir) {
     .sort()
     .reverse();
 
-  return entries[0] ? join('.aspens', 'sessions', entries[0]) : null;
+  return entries[0] ? toPosix(join('.aspens', 'sessions', entries[0])) : null;
 }
 
 const MAX_HANDOFFS = 10;
@@ -306,7 +308,7 @@ function extractSessionFacts(projectDir, input) {
 
   const transcriptPath = input.transcript_path || input.transcriptPath || '';
   const resolvedTranscriptPath = transcriptPath ? resolve(projectDir, transcriptPath) : '';
-  const transcriptRelPath = resolvedTranscriptPath ? relative(projectDir, resolvedTranscriptPath) : '';
+  const transcriptRelPath = resolvedTranscriptPath ? toPosix(relative(projectDir, resolvedTranscriptPath)) : '';
   const transcriptInsideProject = transcriptRelPath === '' || (!transcriptRelPath.startsWith('..') && !transcriptRelPath.startsWith('/') && !transcriptRelPath.includes('..\\'));
 
   if (!resolvedTranscriptPath || !transcriptInsideProject || !existsSync(resolvedTranscriptPath)) {

--- a/tests/doc-sync-repair.test.js
+++ b/tests/doc-sync-repair.test.js
@@ -93,7 +93,7 @@ describe('repairDeterministicSections', () => {
         '',
         '## Skills',
         '',
-        '- old stale entry',
+        '- `.claude/skills/deleted/skill.md` — Removed domain',
         '',
         '## Behavior',
         '',
@@ -109,10 +109,58 @@ describe('repairDeterministicSections', () => {
     );
 
     expect(result.length).toBeGreaterThan(0);
-    const claudeMd = readFileSync(join(fixtureRoot, 'CLAUDE.md'), 'utf8');
+    const claudeMd = readFileSync(join(fixtureRoot, 'CLAUDE.md'), 'utf8').replace(/\\/g, '/');
     expect(claudeMd).toContain('.claude/skills/base/skill.md');
     expect(claudeMd).toContain('.claude/skills/billing/skill.md');
     expect(claudeMd).toContain('.claude/skills/auth/skill.md');
-    expect(claudeMd).not.toContain('old stale entry');
+    expect(claudeMd).not.toContain('.claude/skills/deleted/skill.md');
+  });
+
+  it('writes skill refs with forward slashes on every platform (issue #53)', () => {
+    seedSkillsAndInstructions();
+
+    repairDeterministicSections(
+      fixtureRoot,
+      TARGETS.claude,
+      [TARGETS.claude],
+      { domains: [] },
+    );
+
+    const claudeMd = readFileSync(join(fixtureRoot, 'CLAUDE.md'), 'utf8');
+    expect(claudeMd).not.toContain('\\');
+    expect(claudeMd).toContain('.claude/skills/base/skill.md');
+    expect(claudeMd).toContain('.claude/skills/billing/skill.md');
+    expect(claudeMd).toContain('.claude/skills/auth/skill.md');
+  });
+
+  it('keeps hand-written lines in the Skills and Behavior sections (issue #52)', () => {
+    seedSkillsAndInstructions({
+      instructionsContent: [
+        '# Test',
+        '',
+        '## Skills',
+        '',
+        '- `.claude/skills/deleted/skill.md` — Removed domain',
+        '- **Claude Skills** - Ignore .claude/skills/* when editing.',
+        '',
+        '## Behavior',
+        '',
+        '- **Tools** - Prefer native tools like sed or grep. Use CRLF line endings.',
+        '',
+      ].join('\n'),
+    });
+
+    repairDeterministicSections(
+      fixtureRoot,
+      TARGETS.claude,
+      [TARGETS.claude],
+      { domains: [] },
+    );
+
+    const claudeMd = readFileSync(join(fixtureRoot, 'CLAUDE.md'), 'utf8');
+    expect(claudeMd).toContain('- **Claude Skills** - Ignore .claude/skills/* when editing.');
+    expect(claudeMd).toContain('- **Tools** - Prefer native tools like sed or grep. Use CRLF line endings.');
+    expect(claudeMd).toContain('Verify before claiming');
+    expect(claudeMd.replace(/\\/g, '/')).not.toContain('.claude/skills/deleted/skill.md');
   });
 });

--- a/tests/doc-sync-repair.test.js
+++ b/tests/doc-sync-repair.test.js
@@ -15,7 +15,11 @@ import { mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
-import { repairDeterministicSections } from '../src/commands/doc-sync.js';
+import { mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+
+import { repairDeterministicSections, docSyncCommand } from '../src/commands/doc-sync.js';
+import { CliError } from '../src/lib/errors.js';
 import { TARGETS } from '../src/lib/target.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -162,5 +166,28 @@ describe('repairDeterministicSections', () => {
     expect(claudeMd).toContain('- **Tools** - Prefer native tools like sed or grep. Use CRLF line endings.');
     expect(claudeMd).toContain('Verify before claiming');
     expect(claudeMd.replace(/\\/g, '/')).not.toContain('.claude/skills/deleted/skill.md');
+  });
+});
+
+/**
+ * Regression: `projectPrefix` used to be computed from `getGitRoot()` before the
+ * "Not a git repository" guard ran, so a non-Git directory failed with a raw
+ * `TypeError` from `path.relative(null, ...)` instead of the CliError
+ * remediation message.
+ */
+describe('docSyncCommand outside a Git repository', () => {
+  let nonGitDir;
+
+  beforeAll(() => {
+    nonGitDir = mkdtempSync(join(tmpdir(), 'aspens-nongit-'));
+  });
+
+  afterAll(() => {
+    rmSync(nonGitDir, { recursive: true, force: true });
+  });
+
+  it('throws CliError with the git remediation message, not a TypeError', async () => {
+    await expect(docSyncCommand(nonGitDir, {})).rejects.toThrow(CliError);
+    await expect(docSyncCommand(nonGitDir, {})).rejects.toThrow(/Not a git repository/);
   });
 });

--- a/tests/git-hook.test.js
+++ b/tests/git-hook.test.js
@@ -30,7 +30,7 @@ describe.sequential('installGitHook', () => {
     expect(content).toContain('# <<< aspens doc-sync hook (.) <<<');
   });
 
-  it('makes hook executable', () => {
+  it.skipIf(process.platform === 'win32')('makes hook executable', () => {
     installGitHook(TEST_DIR);
     const mode = statSync(HOOK_PATH).mode;
     expect(mode & 0o111).toBeGreaterThan(0);

--- a/tests/save-tokens-hook-lib.test.js
+++ b/tests/save-tokens-hook-lib.test.js
@@ -136,7 +136,7 @@ describe('save-tokens hook telemetry', () => {
     writeFileSync(join(sessionsDir, '2026-01-01T00-00-00-000Z-claude-handoff.md'), 'old\n', 'utf8');
     writeFileSync(join(sessionsDir, '2026-02-01T00-00-00-000Z-claude-handoff.md'), 'new\n', 'utf8');
 
-    expect(latestHandoff(TEST_DIR)).toBe(join('.aspens', 'sessions', '2026-02-01T00-00-00-000Z-claude-handoff.md'));
+    expect(latestHandoff(TEST_DIR)).toBe('.aspens/sessions/2026-02-01T00-00-00-000Z-claude-handoff.md');
   });
 
   it('prunes old handoffs without removing session support files', () => {

--- a/tests/target-transform.test.js
+++ b/tests/target-transform.test.js
@@ -355,6 +355,32 @@ describe('syncSkillsSection', () => {
     expect(out).toContain('.claude/skills/billing/skill.md');
   });
 
+  it('preserves hand-written links to files under a skill directory (CodeRabbit PR #54)', () => {
+    const claudeMd = [
+      '# Project',
+      '',
+      '## Skills',
+      '',
+      '- `.claude/skills/removed/skill.md` — Deleted domain',
+      '- `.claude/skills/base/reference/api.md` — API notes',
+      '- `.claude/skills/auth/CHECKLIST.md` — Review checklist',
+      '',
+      '## Conventions',
+      '',
+      'stuff',
+      '',
+    ].join('\n');
+    const out = syncSkillsSection(claudeMd, baseSkill, domainSkills, TARGETS.claude, false).replace(/\\/g, '/');
+    // Deeper and differently named paths are hand-written references, not
+    // generated entry points, so they survive the sync.
+    expect(out).toContain('`.claude/skills/base/reference/api.md`');
+    expect(out).toContain('`.claude/skills/auth/CHECKLIST.md`');
+    // A stale generated entry point is still replaced.
+    expect(out).not.toContain('.claude/skills/removed/skill.md');
+    expect(out).toContain('.claude/skills/auth/skill.md');
+    expect(out.match(/## Skills/g)).toHaveLength(1);
+  });
+
   it('uses Codex paths and casing when destTarget is codex', () => {
     const agentsMd = '# Project\n';
     const out = syncSkillsSection(agentsMd, baseSkill, domainSkills, TARGETS.codex, true);

--- a/tests/target-transform.test.js
+++ b/tests/target-transform.test.js
@@ -323,13 +323,36 @@ describe('syncSkillsSection', () => {
     expect(out).toContain('Billing flows');
   });
 
-  it('overwrites an existing Skills section rather than duplicating it', () => {
-    const claudeMd = '# Project\n\n## Skills\n\n- only-one-stale-entry\n\n## Conventions\n\nstuff\n';
-    const out = syncSkillsSection(claudeMd, baseSkill, domainSkills, TARGETS.claude, false);
+  it('refreshes generated skill refs rather than duplicating the section', () => {
+    const claudeMd = '# Project\n\n## Skills\n\n- `.claude/skills/removed/skill.md` — Deleted domain\n\n## Conventions\n\nstuff\n';
+    const out = syncSkillsSection(claudeMd, baseSkill, domainSkills, TARGETS.claude, false).replace(/\\/g, '/');
     expect(out.match(/## Skills/g)).toHaveLength(1);
-    expect(out).not.toContain('only-one-stale-entry');
+    expect(out).not.toContain('.claude/skills/removed/skill.md');
     expect(out).toContain('.claude/skills/auth/skill.md');
     expect(out).toContain('## Conventions');
+  });
+
+  it('preserves hand-written lines inside the Skills section (issue #52)', () => {
+    const claudeMd = [
+      '# Project',
+      '',
+      '## Skills',
+      '',
+      '- `.claude/skills/removed/skill.md` — Deleted domain',
+      '- **Claude Skills** - Ignore .claude/skills/* when editing.',
+      '',
+      'Load the auth skill before touching tokens.',
+      '',
+      '## Conventions',
+      '',
+      'stuff',
+      '',
+    ].join('\n');
+    const out = syncSkillsSection(claudeMd, baseSkill, domainSkills, TARGETS.claude, false).replace(/\\/g, '/');
+    expect(out).toContain('- **Claude Skills** - Ignore .claude/skills/* when editing.');
+    expect(out).toContain('Load the auth skill before touching tokens.');
+    expect(out).not.toContain('.claude/skills/removed/skill.md');
+    expect(out).toContain('.claude/skills/billing/skill.md');
   });
 
   it('uses Codex paths and casing when destTarget is codex', () => {
@@ -380,13 +403,74 @@ describe('syncBehaviorSection', () => {
     expect(out).toContain('Surgical changes');
   });
 
-  it('overwrites an existing Behavior section, never duplicating it', () => {
-    const input = '# Project\n\n## Behavior\n\n- stale rule\n\n## Conventions\n\nstuff\n';
+  it('refreshes an outdated canonical rule in place, never duplicating the section', () => {
+    const input = '# Project\n\n## Behavior\n\n- **Surgical changes** — outdated wording from an older aspens\n\n## Conventions\n\nstuff\n';
     const out = syncBehaviorSection(input);
     expect(out.match(/## Behavior/g)).toHaveLength(1);
-    expect(out).not.toContain('stale rule');
-    expect(out).toContain('Surgical changes');
+    expect(out.match(/\*\*Surgical changes\*\*/g)).toHaveLength(1);
+    expect(out).not.toContain('outdated wording from an older aspens');
+    expect(out).toContain('Touch only what the task requires.');
     expect(out).toContain('## Conventions');
+  });
+
+  it('preserves hand-written rules alongside the canonical ones (issue #52)', () => {
+    const input = [
+      '# Project',
+      '',
+      '## Behavior',
+      '',
+      '- **Verify before claiming** — old text',
+      '- **Tools** - Prefer native tools like sed or grep. Use CRLF line endings.',
+      '- **Claude Skills** - Ignore .claude/skills/* when editing.',
+      '',
+      '## Conventions',
+      '',
+      'stuff',
+      '',
+    ].join('\n');
+    const out = syncBehaviorSection(input);
+    expect(out).toContain('- **Tools** - Prefer native tools like sed or grep. Use CRLF line endings.');
+    expect(out).toContain('- **Claude Skills** - Ignore .claude/skills/* when editing.');
+    expect(out).not.toContain('old text');
+    expect(out.match(/\*\*Verify before claiming\*\*/g)).toHaveLength(1);
+    expect(out).toContain('## Conventions');
+  });
+
+  it('is idempotent across repeated syncs', () => {
+    const input = '# Project\n\n## Behavior\n\n- **Tools** - mine\n\n## Conventions\n\nstuff\n';
+    const once = syncBehaviorSection(input);
+    expect(syncBehaviorSection(once)).toBe(once);
+  });
+
+  it('keeps CRLF line endings on Windows files', () => {
+    const input = '# Project\r\n\r\n## Behavior\r\n\r\n- **Tools** - mine\r\n\r\n## Conventions\r\n\r\nstuff\r\n';
+    const out = syncBehaviorSection(input);
+    expect(out).toContain('- **Tools** - mine');
+    expect(out.split('\n').filter(l => l.length > 0 && !l.endsWith('\r'))).toHaveLength(0);
+  });
+
+  it('leaves the end of the file exactly as it found it', () => {
+    const withNewline = '# Project\n\n## Behavior\n\n- **Tools** - mine\n';
+    const withoutNewline = '# Project\n\n## Behavior\n\n- **Tools** - mine';
+
+    expect(syncBehaviorSection(withNewline).endsWith('- **Tools** - mine\n')).toBe(true);
+    expect(syncBehaviorSection(withoutNewline).endsWith('- **Tools** - mine')).toBe(true);
+  });
+
+  it('does not insert a blank line between canonical and hand-written rules', () => {
+    const input = '# Project\n\n## Behavior\n\n- **Tools** - mine\n\n## Conventions\n\nstuff\n';
+    const out = syncBehaviorSection(input);
+    expect(out).toMatch(/- \*\*Surgical changes\*\*[^\n]*\n- \*\*Tools\*\* - mine\n/);
+  });
+
+  it('returns hand-written lines with their own line endings on a mixed file', () => {
+    const input = '# Project\n\n## Behavior\n\n- **Tools** - mine\r\n\n## Conventions\n\nstuff\n';
+    const out = syncBehaviorSection(input);
+    expect(out).toContain('- **Tools** - mine\r\n');
+    expect(out).toContain('- **Verify before claiming**');
+    const canonical = out.split('\n').filter(l => l.startsWith('- **Verify before claiming**'));
+    expect(canonical).toHaveLength(1);
+    expect(canonical[0].endsWith('\r')).toBe(false);
   });
 });
 


### PR DESCRIPTION
Fixes #52, fixes #53.

## Problem

`aspens doc sync` rewrote the `## Skills` and `## Behavior` sections of CLAUDE.md/AGENTS.md wholesale, so any hand-written line inside them was deleted on the next sync (#52).

Separately, on Windows the skill references were written with backslashes (`.claude\skills\billing\skill.md`), which do not match the paths the rest of the tooling expects (#53).

## Fix

**Additive merge.** 
- The deterministic sync now rebuilds only the lines it owns. 
- Canonical entries (generated skill refs and the known behavior rules, matched by rule label) are refreshed in place; every other line in the section is kept, in order, with its own line ending. 
- Stale generated refs are still dropped. 
- Repeated syncs are byte-stable on LF, CRLF, and mixed-ending files.

**POSIX paths.** 
- New `src/lib/posix-path.js` (`toPosix`, `relativePosix`, `toPosixRelative`) replaces the per-module helpers and is applied at every point where a filesystem path becomes a logical path written into generated content. 
- `path.posix` is not usable here as it does not translate `\` on Windows input.

## Tests

New coverage in `tests/target-transform.test.js` and `tests/doc-sync-repair.test.js`:

- hand-written lines survive in both sections
- no blank line inserted between canonical and hand-written rules
- CRLF and mixed line endings preserved per line
- end-of-file bytes unchanged
- skill refs contain no backslash on any platform
- repeated sync writes nothing

The `makes hook executable` test is now skipped on win32 (NTFS has no exec bit).

Verified locally against previously problematic repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Standardized generated file and skill paths to use forward slashes across platforms, including Windows.
  - Improved project synchronization so outdated generated entries are refreshed without removing hand-written content.
  - Preserved custom Behavior and Skills section lines during repeated synchronization.
  - Improved handling of line endings and file endings during generated documentation updates.
  - Corrected path handling for framework detection, repository scanning, impact analysis, hooks, and session handoffs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->