### PR TITLE
feat: detect CI/CD platforms during repo scan

### DIFF
--- a/src/commands/scan.js
+++ b/src/commands/scan.js
@@ -45,6 +45,10 @@ export async function scanCommand(path, options) {
     console.log(pc.cyan('  Frameworks: ') + result.frameworks.join(', '));
   }
 
+  if (result.cicd.length > 0) {
+    console.log(pc.cyan('  CI/CD: ') + result.cicd.join(', '));
+  }
+
   if (result.entryPoints.length > 0) {
     console.log(pc.cyan('  Entry points: ') + result.entryPoints.join(', '));
   }

--- a/src/lib/cicd.js
+++ b/src/lib/cicd.js
@@ -1,0 +1,84 @@
+/**
+ * CI/CD platform detector — deterministic, filesystem only.
+ *
+ * A platform is matched by any of three marker kinds:
+ *   - `files` — exact filename, no extension (Jenkinsfile)
+ *   - `stems` — filename without extension, combined with every CICD_EXT
+ *   - `dirs`  — directory holding one or more CI config files
+ *
+ * Directory markers exist because a pipeline is rarely a single file: the
+ * entry config usually sits alongside imported/included job files, and some
+ * platforms name the entry file freely (`.github/workflows/*.yml`). Scanning
+ * the directory catches those, including one level of nesting such as
+ * `.buildkite/pipelines/deploy.yml`.
+ *
+ * Results follow PLATFORMS order, so they are stable across runs.
+ */
+
+import { existsSync, readdirSync, statSync } from 'fs';
+import { join } from 'path';
+
+const CICD_EXTS = ['.yml', '.yaml'];
+
+const NESTED_SCAN_DEPTH = 2;
+
+const PLATFORMS = [
+  { id: 'github-actions', dirs: ['.github/workflows'] },
+  { id: 'gitlab-ci', stems: ['.gitlab-ci'], dirs: ['.gitlab/ci'] },
+  { id: 'circleci', dirs: ['.circleci'] },
+  { id: 'jenkins', files: ['Jenkinsfile'] },
+  { id: 'travis-ci', stems: ['.travis'] },
+  { id: 'azure-pipelines', stems: ['azure-pipelines', '.azure-pipelines'] },
+  { id: 'bitbucket-pipelines', stems: ['bitbucket-pipelines'] },
+  { id: 'buildkite', dirs: ['.buildkite'] },
+];
+
+/**
+ * Detect CI/CD platforms configured in a repo.
+ *
+ * @param {string} repoPath
+ * @returns {string[]} platform ids, empty when none are configured
+ */
+export function detectCICD(repoPath) {
+  const found = [];
+
+  for (const platform of PLATFORMS) {
+    if (matchesPlatform(repoPath, platform)) found.push(platform.id);
+  }
+
+  return found;
+}
+
+function matchesPlatform(repoPath, { files = [], stems = [], dirs = [] }) {
+  if (files.some(file => existsSync(join(repoPath, file)))) return true;
+  if (stems.some(stem => CICD_EXTS.some(ext => existsSync(join(repoPath, stem + ext))))) return true;
+  return dirs.some(dir => hasConfigFile(join(repoPath, dir), NESTED_SCAN_DEPTH));
+}
+
+function hasConfigFile(dirPath, depth) {
+  if (depth <= 0) return false;
+
+  for (const entry of listDir(dirPath)) {
+    if (CICD_EXTS.some(ext => entry.endsWith(ext))) return true;
+    const full = join(dirPath, entry);
+    if (isDir(full) && hasConfigFile(full, depth - 1)) return true;
+  }
+
+  return false;
+}
+
+function listDir(dirPath) {
+  try {
+    return readdirSync(dirPath);
+  } catch {
+    return [];
+  }
+}
+
+function isDir(filePath) {
+  try {
+    return statSync(filePath).isDirectory();
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/cicd.js
+++ b/src/lib/cicd.js
@@ -50,6 +50,15 @@ export function detectCICD(dirPath) {
   return found;
 }
 
+/**
+ * Test one platform's markers against a repo.
+ *
+ * Any single marker is enough — a platform is configured, not scored.
+ *
+ * @param {string} repoPath Absolute repo root.
+ * @param {{files?: string[], stems?: string[], dirs?: string[]}} platform Marker sets.
+ * @returns {boolean}
+ */
 function matchesPlatform(repoPath, { files = [], stems = [], dirs = [] }) {
   // A marker only counts as config when it is a regular file — a directory
   // named `Jenkinsfile` or `.travis.yml` configures nothing.
@@ -58,6 +67,16 @@ function matchesPlatform(repoPath, { files = [], stems = [], dirs = [] }) {
   return dirs.some(dir => hasConfigFile(join(repoPath, dir), NESTED_SCAN_DEPTH));
 }
 
+/**
+ * Look for a CI config file in a directory, descending `depth` levels.
+ *
+ * A missing or unreadable directory reads as no config rather than an error:
+ * the scan describes what it can see and never fails a repo over permissions.
+ *
+ * @param {string} dirPath Directory to search.
+ * @param {number} depth Levels left to descend; 0 stops the search.
+ * @returns {boolean}
+ */
 function hasConfigFile(dirPath, depth) {
   if (depth <= 0) return false;
 

--- a/src/lib/cicd.js
+++ b/src/lib/cicd.js
@@ -64,36 +64,58 @@ function matchesPlatform(repoPath, { files = [], stems = [], dirs = [] }) {
   // named `Jenkinsfile` or `.travis.yml` configures nothing.
   if (files.some(file => isFile(join(repoPath, file)))) return true;
   if (stems.some(stem => CICD_EXTS.some(ext => isFile(join(repoPath, stem + ext))))) return true;
-  return dirs.some(dir => hasConfigFile(join(repoPath, dir), NESTED_SCAN_DEPTH));
+  // An unreadable directory is unknown, not empty — credit the platform
+  // rather than silently dropping it.
+  return dirs.some(dir => hasConfigFile(join(repoPath, dir), NESTED_SCAN_DEPTH) ?? true);
 }
 
 /**
  * Look for a CI config file in a directory, descending `depth` levels.
  *
- * A missing or unreadable directory reads as no config rather than an error:
- * the scan describes what it can see and never fails a repo over permissions.
+ * Three outcomes, because "no config" and "could not look" are different
+ * facts: true for a config file found, false for a directory searched with
+ * nothing in it, null when a directory could not be read at all. A missing
+ * directory is a clean false — there is nothing there to hide. Exhausting
+ * `depth` is also false: a deliberate bound, not a failure.
  *
  * @param {string} dirPath Directory to search.
  * @param {number} depth Levels left to descend; 0 stops the search.
- * @returns {boolean}
+ * @returns {boolean|null} null when the search was blocked by the filesystem.
  */
 function hasConfigFile(dirPath, depth) {
   if (depth <= 0) return false;
 
-  for (const entry of listDir(dirPath)) {
+  const entries = listDir(dirPath);
+  if (entries === null) return isDir(dirPath) ? null : false;
+
+  let blocked = false;
+
+  for (const entry of entries) {
     const full = join(dirPath, entry);
     if (CICD_EXTS.some(ext => entry.endsWith(ext)) && isFile(full)) return true;
-    if (isDir(full) && hasConfigFile(full, depth - 1)) return true;
+    if (!isDir(full)) continue;
+
+    const nested = hasConfigFile(full, depth - 1);
+    if (nested) return true;
+    if (nested === null) blocked = true;
   }
 
-  return false;
+  // A subdirectory we could not read may hold the config, so the answer for
+  // this directory is unknown rather than no.
+  return blocked ? null : false;
 }
 
+/**
+ * Read a directory's entries, or null when the filesystem refuses.
+ *
+ * @param {string} dirPath
+ * @returns {string[]|null}
+ */
 function listDir(dirPath) {
   try {
     return readdirSync(dirPath);
   } catch {
-    return [];
+    return null;
   }
 }
 

--- a/src/lib/cicd.js
+++ b/src/lib/cicd.js
@@ -15,8 +15,8 @@
  * Results follow PLATFORMS order, so they are stable across runs.
  */
 
-import { existsSync, readdirSync, statSync } from 'fs';
-import { join } from 'path';
+import { readdirSync, statSync } from 'fs';
+import { join, resolve } from 'path';
 
 const CICD_EXTS = ['.yml', '.yaml'];
 
@@ -36,10 +36,11 @@ const PLATFORMS = [
 /**
  * Detect CI/CD platforms configured in a repo.
  *
- * @param {string} repoPath
+ * @param {string} dirPath Repo root; normalised with resolve().
  * @returns {string[]} platform ids, empty when none are configured
  */
-export function detectCICD(repoPath) {
+export function detectCICD(dirPath) {
+  const repoPath = resolve(dirPath);
   const found = [];
 
   for (const platform of PLATFORMS) {
@@ -50,8 +51,10 @@ export function detectCICD(repoPath) {
 }
 
 function matchesPlatform(repoPath, { files = [], stems = [], dirs = [] }) {
-  if (files.some(file => existsSync(join(repoPath, file)))) return true;
-  if (stems.some(stem => CICD_EXTS.some(ext => existsSync(join(repoPath, stem + ext))))) return true;
+  // A marker only counts as config when it is a regular file — a directory
+  // named `Jenkinsfile` or `.travis.yml` configures nothing.
+  if (files.some(file => isFile(join(repoPath, file)))) return true;
+  if (stems.some(stem => CICD_EXTS.some(ext => isFile(join(repoPath, stem + ext))))) return true;
   return dirs.some(dir => hasConfigFile(join(repoPath, dir), NESTED_SCAN_DEPTH));
 }
 
@@ -59,8 +62,8 @@ function hasConfigFile(dirPath, depth) {
   if (depth <= 0) return false;
 
   for (const entry of listDir(dirPath)) {
-    if (CICD_EXTS.some(ext => entry.endsWith(ext))) return true;
     const full = join(dirPath, entry);
+    if (CICD_EXTS.some(ext => entry.endsWith(ext)) && isFile(full)) return true;
     if (isDir(full) && hasConfigFile(full, depth - 1)) return true;
   }
 
@@ -78,6 +81,14 @@ function listDir(dirPath) {
 function isDir(filePath) {
   try {
     return statSync(filePath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function isFile(filePath) {
+  try {
+    return statSync(filePath).isFile();
   } catch {
     return false;
   }

--- a/src/lib/context-builder.js
+++ b/src/lib/context-builder.js
@@ -207,7 +207,8 @@ export function buildDomainContext(repoPath, scanResult, domain, options = {}) {
   const readFiles = new Set();
 
   // 1. Brief repo summary (not full scan — just enough for orientation)
-  sections.push(`## Repository: ${scanResult.name} (${scanResult.repoType})\nTech: ${scanResult.frameworks.join(', ')}`);
+  const cicdLine = scanResult.cicd?.length ? `\nCI/CD: ${scanResult.cicd.join(', ')}` : '';
+  sections.push(`## Repository: ${scanResult.name} (${scanResult.repoType})\nTech: ${scanResult.frameworks.join(', ')}${cicdLine}`);
 
   // 2. All files from this domain — more generous than full-repo mode
   const filesToRead = [];

--- a/src/lib/scanner.js
+++ b/src/lib/scanner.js
@@ -2,6 +2,7 @@ import { readFileSync, existsSync, readdirSync, statSync } from 'fs';
 import { join, basename, extname } from 'path';
 import { SOURCE_EXTS } from './source-exts.js';
 import { relativePosix, toPosix } from './posix-path.js';
+import { detectCICD } from './cicd.js';
 
 /**
  * Scan a repository and return its tech stack, structure, and domains.
@@ -16,6 +17,7 @@ export function scanRepo(repoPath, { extraDomains } = {}) {
     structure: detectStructure(repoPath),
     domains: detectDomains(repoPath),
     entryPoints: detectEntryPoints(repoPath),
+    cicd: detectCICD(repoPath),
     hasClaudeConfig: existsSync(join(repoPath, '.claude')),
     hasClaudeMd: existsSync(join(repoPath, 'CLAUDE.md')),
     hasCodexConfig: existsSync(join(repoPath, '.codex')),

--- a/tests/cicd.test.js
+++ b/tests/cicd.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { join, resolve } from 'path';
+
+// The behaviour under test is a filesystem refusal, which cannot be staged
+// portably with real files — Windows ACLs and POSIX modes disagree, and CI
+// often runs as root, where a mode of 000 is still readable.
+const fsState = { dirs: new Set(), files: new Set(), unreadable: new Set(), entries: new Map() };
+
+vi.mock('fs', () => ({
+  readdirSync: (path) => {
+    const key = String(path);
+    if (fsState.unreadable.has(key)) throw Object.assign(new Error('EPERM'), { code: 'EPERM' });
+    if (fsState.files.has(key)) throw Object.assign(new Error('ENOTDIR'), { code: 'ENOTDIR' });
+    if (!fsState.dirs.has(key)) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    return fsState.entries.get(key) || [];
+  },
+  statSync: (path) => {
+    const key = String(path);
+    const isDirectory = fsState.dirs.has(key);
+    const isFile = fsState.files.has(key);
+    if (!isDirectory && !isFile) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    return { isDirectory: () => isDirectory, isFile: () => isFile };
+  },
+}));
+
+const { detectCICD } = await import('../src/lib/cicd.js');
+
+const ROOT = resolve('/repo');
+
+function dir(relative, entries = []) {
+  const full = relative ? join(ROOT, relative) : ROOT;
+  fsState.dirs.add(full);
+  fsState.entries.set(full, entries);
+  return full;
+}
+
+describe('CI/CD detection when the filesystem refuses', () => {
+  beforeEach(() => {
+    fsState.dirs.clear();
+    fsState.files.clear();
+    fsState.unreadable.clear();
+    fsState.entries.clear();
+    dir('');
+  });
+
+  it('credits a platform whose config directory cannot be read', () => {
+    fsState.unreadable.add(dir('.circleci'));
+    // Unknown, not empty — dropping it would hide a configured platform.
+    expect(detectCICD(ROOT)).toEqual(['circleci']);
+  });
+
+  it('credits a platform when a nested directory cannot be read', () => {
+    dir('.buildkite', ['pipelines']);
+    fsState.unreadable.add(dir('.buildkite/pipelines'));
+    expect(detectCICD(ROOT)).toEqual(['buildkite']);
+  });
+
+  it('ignores a config directory that is readable and empty', () => {
+    dir('.circleci', []);
+    expect(detectCICD(ROOT)).toEqual([]);
+  });
+
+  it('ignores a config directory that is readable and holds no CI config', () => {
+    dir('.circleci', ['README.md']);
+    fsState.files.add(join(ROOT, '.circleci', 'README.md'));
+    expect(detectCICD(ROOT)).toEqual([]);
+  });
+
+  it('ignores a marker directory name that is really a file', () => {
+    fsState.files.add(join(ROOT, '.circleci'));
+    expect(detectCICD(ROOT)).toEqual([]);
+  });
+
+  it('ignores a config directory that does not exist', () => {
+    expect(detectCICD(ROOT)).toEqual([]);
+  });
+});

--- a/tests/scanner.test.js
+++ b/tests/scanner.test.js
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { mkdirSync, writeFileSync, rmSync, existsSync } from 'fs';
-import { join } from 'path';
+import { join, sep } from 'path';
 import { scanRepo } from '../src/lib/scanner.js';
+import { detectCICD } from '../src/lib/cicd.js';
 
 const FIXTURES_DIR = join(import.meta.dirname, 'fixtures', 'scanner');
 
@@ -446,11 +447,29 @@ describe('scanRepo', () => {
         files: { 'package.json': '{}' },
         expected: [],
       },
+      {
+        name: 'nothing from a directory named like a root config file',
+        files: { 'Jenkinsfile/notes.md': 'not a pipeline', '.travis.yml/notes.md': 'nor this' },
+        expected: [],
+      },
+      {
+        name: 'nothing from a directory named like a pipeline file',
+        files: { '.github/workflows/ci.yml/notes.md': 'not a workflow' },
+        expected: [],
+      },
     ];
 
     it.each(cases)('detects $name', ({ name, files, expected }) => {
       const dir = createFixture(`cicd-${name.replace(/[^a-z0-9]+/gi, '-')}`, files);
       expect(scanRepo(dir).cicd).toEqual(expected);
+    });
+
+    it('normalises the repo path before checking markers', () => {
+      const dir = createFixture('cicd-trailing-sep', {
+        'package.json': '{}',
+        '.circleci/config.yml': 'version: 2.1',
+      });
+      expect(detectCICD(dir + sep)).toEqual(['circleci']);
     });
   });
 

--- a/tests/scanner.test.js
+++ b/tests/scanner.test.js
@@ -384,6 +384,76 @@ describe('scanRepo', () => {
     });
   });
 
+  describe('CI/CD detection', () => {
+    const cases = [
+      {
+        name: 'GitHub Actions from a workflow file',
+        files: { '.github/workflows/ci.yml': 'name: CI' },
+        expected: ['github-actions'],
+      },
+      {
+        name: 'GitLab CI from the root config',
+        files: { '.gitlab-ci.yml': 'stages: [test]' },
+        expected: ['gitlab-ci'],
+      },
+      {
+        name: 'GitLab CI from included job files alone',
+        files: { '.gitlab/ci/test.yml': 'test: {}' },
+        expected: ['gitlab-ci'],
+      },
+      {
+        name: 'CircleCI from a nested config',
+        files: { '.circleci/config.yml': 'version: 2.1' },
+        expected: ['circleci'],
+      },
+      {
+        name: 'Jenkins from an extensionless Jenkinsfile',
+        files: { 'Jenkinsfile': 'pipeline {}' },
+        expected: ['jenkins'],
+      },
+      {
+        name: 'a .yaml variant of a root config file',
+        files: { 'azure-pipelines.yaml': 'trigger: [main]' },
+        expected: ['azure-pipelines'],
+      },
+      {
+        name: 'a dot-prefixed variant of a root config file',
+        files: { '.azure-pipelines.yml': 'trigger: [main]' },
+        expected: ['azure-pipelines'],
+      },
+      {
+        name: 'Bitbucket Pipelines from the root config',
+        files: { 'bitbucket-pipelines.yml': 'pipelines: {}' },
+        expected: ['bitbucket-pipelines'],
+      },
+      {
+        name: 'a platform from pipeline files nested in its config directory',
+        files: { '.buildkite/pipelines/deploy.yaml': 'steps: []' },
+        expected: ['buildkite'],
+      },
+      {
+        name: 'multiple platforms, in table order',
+        files: { '.github/workflows/ci.yaml': 'name: CI', '.travis.yml': 'language: node_js' },
+        expected: ['github-actions', 'travis-ci'],
+      },
+      {
+        name: 'nothing from a config directory with no CI config files',
+        files: { '.github/workflows/README.md': 'no workflows yet' },
+        expected: [],
+      },
+      {
+        name: 'nothing from a repo with no CI/CD config',
+        files: { 'package.json': '{}' },
+        expected: [],
+      },
+    ];
+
+    it.each(cases)('detects $name', ({ name, files, expected }) => {
+      const dir = createFixture(`cicd-${name.replace(/[^a-z0-9]+/gi, '-')}`, files);
+      expect(scanRepo(dir).cicd).toEqual(expected);
+    });
+  });
+
   describe('claude config detection', () => {
     it('detects .claude directory', () => {
       const dir = createFixture('claude-config', {


### PR DESCRIPTION
Fixes #5.

## Problem

`aspens scan` reported languages, frameworks, and entry points, but nothing about how a project builds or deploys. A generated skill could not say "tests run via GitHub Actions on PR" because the scan result carried no CI/CD information.

## Fix

**New detector module.**
- `src/lib/cicd.js` exports `detectCICD(repoPath)`, called from `scanRepo()` and exposed as `scanResult.cicd`.
- Filesystem only, no LLM call, in line with the rest of the scanner.

**Table-driven markers.** Each platform declares any of three marker kinds:
- `files`: an exact filename, for configs with no extension (`Jenkinsfile`).
- `stems`: a filename without its extension, combined with a shared `CICD_EXTS` list, so `.yml` and `.yaml` are handled once for every platform.
- `dirs`: a config directory, scanned for any CI config file.

Directory markers matter because a pipeline is usually more than one file. The entry config sits alongside imported job files, and some platforms let you name the entry file freely. The scan goes two levels deep, so it finds `.github/workflows/*.yml`, `.circleci/config.yml` with its sibling job files, `.buildkite/pipelines/deploy.yaml`, and `.gitlab/ci/*.yml` includes in a repo with no root `.gitlab-ci.yml`.

Covers GitHub Actions, GitLab CI, CircleCI, Jenkins, Travis CI, Azure Pipelines, Bitbucket Pipelines, and Buildkite. Results follow table order, so they are stable across runs.

**Surfacing.**
- `aspens scan` prints a `CI/CD:` line after Frameworks.
- `buildContext` and `buildBaseContext` already serialize the whole scan result into prompt context, so only the chunked-mode summary in `buildDomainContext` needed an explicit line.

## Tests

New `CI/CD detection` block in `tests/scanner.test.js`, written as an `it.each` table so adding a platform is one row:

- each marker kind: extensionless file, root stem, config directory
- `.yaml` and dot-prefixed variants of a root config
- pipeline files nested one level inside a config directory
- a platform found from included job files alone
- multiple platforms, asserting table order
- a config directory holding no CI config files
- a repo with no CI/CD config

Every case asserts the exact result array instead of membership, so an accidental extra detection fails.

Verified locally: `node bin/cli.js scan .` on this repo prints `CI/CD: github-actions`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scans repositories for configured CI/CD platforms, including GitHub Actions, GitLab CI, CircleCI, Jenkins, Azure Pipelines, Bitbucket Pipelines, and Buildkite.
  * Displays detected CI/CD platforms in scan output and repository summaries.
  * Recognizes CI/CD configuration when marker directories cannot be read, while ignoring missing, empty, or unrelated paths.

* **Tests**
  * Added coverage for supported configurations, trailing path separators, ignored directory markers, unreadable paths, and repositories without CI/CD setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->