### PR TITLE
feat: probe Next.js routing architecture during repo scan

### DIFF
--- a/src/commands/scan.js
+++ b/src/commands/scan.js
@@ -49,6 +49,10 @@ export async function scanCommand(path, options) {
     console.log(pc.cyan('  CI/CD: ') + result.cicd.join(', '));
   }
 
+  if (result.nextjs) {
+    console.log(pc.cyan('  Next.js: ') + describeNextjs(result.nextjs));
+  }
+
   if (result.entryPoints.length > 0) {
     console.log(pc.cyan('  Entry points: ') + result.entryPoints.join(', '));
   }
@@ -300,4 +304,27 @@ function formatGraphForDisplay(graph) {
     coupling,
     hotspots: (hotspots || []).slice(0, 5),
   };
+}
+
+/**
+ * One-line summary of the Next.js architecture probe.
+ */
+function describeNextjs(nextjs) {
+  const parts = [];
+
+  if (nextjs.router === 'migrating') parts.push('App + Pages Router (migrating)');
+  else if (nextjs.router === 'app') parts.push('App Router');
+  else if (nextjs.router === 'pages') parts.push('Pages Router');
+  else parts.push('no router directory');
+
+  parts.push(`${nextjs.routes} ${nextjs.routes === 1 ? 'route' : 'routes'}`);
+  if (nextjs.dynamicRoutes > 0) parts.push(`${nextjs.dynamicRoutes} dynamic`);
+  if (nextjs.apiRoutes > 0) {
+    parts.push(`${nextjs.apiRoutes} API ${nextjs.apiRoutes === 1 ? 'route' : 'routes'}`);
+  }
+  if (nextjs.routeGroups.length > 0) parts.push(`groups: ${nextjs.routeGroups.join(' ')}`);
+  parts.push(`${nextjs.clientComponents} client / ${nextjs.serverComponents} server components`);
+  if (nextjs.middleware) parts.push('middleware');
+
+  return parts.join(', ');
 }

--- a/src/lib/context-builder.js
+++ b/src/lib/context-builder.js
@@ -208,7 +208,11 @@ export function buildDomainContext(repoPath, scanResult, domain, options = {}) {
 
   // 1. Brief repo summary (not full scan — just enough for orientation)
   const cicdLine = scanResult.cicd?.length ? `\nCI/CD: ${scanResult.cicd.join(', ')}` : '';
-  sections.push(`## Repository: ${scanResult.name} (${scanResult.repoType})\nTech: ${scanResult.frameworks.join(', ')}${cicdLine}`);
+  const nextjs = scanResult.nextjs;
+  const nextjsLine = nextjs
+    ? `\nNext.js: ${nextjs.router || 'no router directory'} router, ${nextjs.routes} routes, ${nextjs.apiRoutes} API routes, ${nextjs.clientComponents} client / ${nextjs.serverComponents} server components${nextjs.middleware ? ', middleware' : ''}`
+    : '';
+  sections.push(`## Repository: ${scanResult.name} (${scanResult.repoType})\nTech: ${scanResult.frameworks.join(', ')}${cicdLine}${nextjsLine}`);
 
   // 2. All files from this domain — more generous than full-repo mode
   const filesToRead = [];

--- a/src/lib/frameworks/nextjs.js
+++ b/src/lib/frameworks/nextjs.js
@@ -12,8 +12,8 @@
  * those don't enter the JS/TS import graph.
  */
 
-import { existsSync, readdirSync, statSync } from 'fs';
-import { join, basename, extname } from 'path';
+import { existsSync, readdirSync, statSync, openSync, readSync, closeSync } from 'fs';
+import { join, basename, extname, resolve, sep } from 'path';
 import { relativePosix } from '../posix-path.js';
 
 const APP_ROUTER_FILE_NAMES = new Set([
@@ -54,10 +54,14 @@ export function isNextjsProject(scan) {
  * Returns an array of { path, kind } where path is repo-relative and kind
  * is one of: 'nextjs-app', 'nextjs-pages', 'nextjs-middleware'.
  *
- * @param {string} repoPath
+ * The router walkers also record each file's `stem` for
+ * `probeNextjsArchitecture`; it is stripped from this function's result.
+ *
+ * @param {string} dirPath Repo root; normalised with resolve().
  * @returns {Array<{path: string, kind: string}>}
  */
-export function detectNextjsEntryPoints(repoPath) {
+export function detectNextjsEntryPoints(dirPath) {
+  const repoPath = resolve(dirPath);
   const found = [];
 
   for (const candidate of APP_DIR_CANDIDATES) {
@@ -83,13 +87,15 @@ export function detectNextjsEntryPoints(repoPath) {
           found.push({
             path: relativePosix(repoPath, full),
             kind: 'nextjs-middleware',
+            stem: name,
           });
         }
       }
     }
   }
 
-  return dedupe(found);
+  // `stem` is internal to this module — entry points are a {path, kind} contract.
+  return dedupe(found).map(({ path, kind }) => ({ path, kind }));
 }
 
 function walkAppDir(repoPath, dir, out, depth = 0) {
@@ -113,7 +119,7 @@ function walkAppDir(repoPath, dir, out, depth = 0) {
 
     const stem = basename(entry, ext);
     if (APP_ROUTER_FILE_NAMES.has(stem) || METADATA_ROUTE_NAMES.has(stem)) {
-      out.push({ path: relativePosix(repoPath, full), kind: 'nextjs-app' });
+      out.push({ path: relativePosix(repoPath, full), kind: 'nextjs-app', stem });
     }
   }
 }
@@ -138,7 +144,11 @@ function walkPagesDir(repoPath, dir, out, depth = 0) {
     const ext = extname(entry);
     if (!CODE_EXTS.has(ext)) continue;
 
-    out.push({ path: relativePosix(repoPath, full), kind: 'nextjs-pages' });
+    out.push({
+      path: relativePosix(repoPath, full),
+      kind: 'nextjs-pages',
+      stem: basename(entry, ext),
+    });
   }
 }
 
@@ -165,10 +175,11 @@ function safeIsFile(p) {
  * Returns the implicit Next.js path alias when no tsconfig paths are configured.
  * Modern Next.js projects default to `@/*` → `./src/*` (or `./*` if no src).
  *
- * @param {string} repoPath
+ * @param {string} dirPath Repo root; normalised with resolve().
  * @returns {Array<{prefix: string, replacement: string}>}
  */
-export function nextjsImplicitAliases(repoPath) {
+export function nextjsImplicitAliases(dirPath) {
+  const repoPath = resolve(dirPath);
   const aliases = [];
   const srcDir = join(repoPath, 'src');
   if (existsSync(srcDir) && safeIsDir(srcDir)) {
@@ -177,4 +188,281 @@ export function nextjsImplicitAliases(repoPath) {
     aliases.push({ prefix: '@/', replacement: repoPath });
   }
   return aliases;
+}
+
+// --- Architecture Probe ---
+
+// Pages Router files that are framework plumbing, not routes.
+const PAGES_SPECIAL_STEMS = new Set(['_app', '_document', '_error']);
+
+// Never source, at any depth — nested `node_modules` included.
+const ALWAYS_SKIP_DIRS = new Set(['node_modules', '__pycache__']);
+
+// Build output and assets, which only sit at a walk root. Deeper down these
+// are ordinary names — `app/build/page.tsx` is a route, not a build artifact.
+const ROOT_SKIP_DIRS = new Set(['dist', 'build', 'out', 'coverage', 'public']);
+
+// Enough to clear a license header and reach the directive prologue.
+const DIRECTIVE_HEAD_BYTES = 1024;
+
+const DYNAMIC_SEGMENT = /^\[.+\]$/;
+const ROUTE_GROUP = /^\(.+\)$/;
+
+/**
+ * Describe a Next.js project's routing architecture.
+ *
+ * Returns null when the repo is not a Next.js project — this is the only
+ * part of the scan that reads file contents, so it stays gated.
+ *
+ * @param {string} dirPath Repo root; normalised with resolve().
+ * @param {string[]} frameworks Detected framework slugs.
+ * @returns {{
+ *   router: 'app'|'pages'|'migrating'|null,
+ *   appDir: string|null,
+ *   pagesDir: string|null,
+ *   routes: number,
+ *   apiRoutes: number,
+ *   dynamicRoutes: number,
+ *   routeGroups: string[],
+ *   clientComponents: number,
+ *   serverComponents: number,
+ *   middleware: boolean,
+ * }|null}
+ */
+export function probeNextjsArchitecture(dirPath, frameworks) {
+  if (!isNextjsProject({ frameworks })) return null;
+
+  // Normalise once — directory containment is decided by string prefix below.
+  const repoPath = resolve(dirPath);
+
+  // An `app/` directory only means App Router once it has a layout.
+  const appDir = APP_DIR_CANDIDATES.find(c => hasAppLayout(join(repoPath, c))) || null;
+  const pagesDir = PAGES_DIR_CANDIDATES.find(c => safeIsDir(join(repoPath, c))) || null;
+
+  const appFiles = [];
+  if (appDir) walkAppDir(repoPath, join(repoPath, appDir), appFiles);
+
+  const pagesFiles = [];
+  if (pagesDir) walkPagesDir(repoPath, join(repoPath, pagesDir), pagesFiles);
+
+  // A private folder opts itself and its children out of routing, but its
+  // files are still server components.
+  const routableAppFiles = appFiles.filter(f => !isPrivateAppPath(f.path));
+
+  const apiPrefix = pagesDir ? `${pagesDir}/api/` : null;
+  const pagesApiRoutes = pagesFiles.filter(f => f.path.startsWith(apiPrefix));
+  const pagesRoutes = pagesFiles.filter(
+    f => !f.path.startsWith(apiPrefix) && !isPagesPlumbing(pagesDir, f)
+  );
+
+  // Mid-migration both routers serve traffic, so route counts cover both.
+  const appPages = dedupeByUrl(routableAppFiles.filter(f => f.stem === 'page'), appDir);
+  const appApiRoutes = dedupeByUrl(routableAppFiles.filter(f => f.stem === 'route'), appDir);
+  const routes = [...appPages, ...pagesRoutes];
+  const apiRoutes = appApiRoutes.length + pagesApiRoutes.length;
+  const components = classifyComponents(repoPath, appDir);
+
+  return {
+    router: routerType(appDir, pagesDir),
+    appDir,
+    pagesDir,
+    routes: routes.length,
+    apiRoutes,
+    dynamicRoutes: routes.filter(f => hasDynamicSegment(f.path)).length,
+    routeGroups: collectRouteGroups(routableAppFiles),
+    clientComponents: components.client,
+    serverComponents: components.server,
+    middleware: hasMiddleware(repoPath),
+  };
+}
+
+/**
+ * Next.js opts an `_`-prefixed folder, and everything under it, out of routing.
+ */
+function isPrivateAppPath(posixPath) {
+  return posixPath.split('/').some(segment => segment.startsWith('_'));
+}
+
+/**
+ * `_app`, `_document` and `_error` are framework plumbing only at the Pages
+ * Router root — `pages/docs/_error.tsx` is a route like any other.
+ */
+function isPagesPlumbing(pagesDir, file) {
+  if (!PAGES_SPECIAL_STEMS.has(file.stem)) return false;
+  return file.path.split('/').length === pagesDir.split('/').length + 1;
+}
+
+/**
+ * Collapse App Router files that serve the same URL.
+ *
+ * Route groups and parallel route slots are organisational: `(shop)` and
+ * `@modal` never reach the URL, so `app/@modal/photo/page.tsx` and
+ * `app/photo/page.tsx` are two files behind one route.
+ */
+function dedupeByUrl(files, appDir) {
+  const seen = new Set();
+  return files.filter((file) => {
+    const url = appRouteUrl(file.path, appDir);
+    if (seen.has(url)) return false;
+    seen.add(url);
+    return true;
+  });
+}
+
+function appRouteUrl(posixPath, appDir) {
+  const segments = posixPath.split('/').slice(appDir.split('/').length, -1);
+  return '/' + segments.filter(s => !ROUTE_GROUP.test(s) && !s.startsWith('@')).join('/');
+}
+
+function routerType(appDir, pagesDir) {
+  if (appDir && pagesDir) return 'migrating';
+  if (appDir) return 'app';
+  if (pagesDir) return 'pages';
+  return null;
+}
+
+function hasAppLayout(dir) {
+  if (!safeIsDir(dir)) return false;
+  for (const ext of CODE_EXTS) {
+    if (safeIsFile(join(dir, `layout${ext}`))) return true;
+  }
+  return false;
+}
+
+function hasMiddleware(repoPath) {
+  for (const ext of CODE_EXTS) {
+    if (safeIsFile(join(repoPath, `middleware${ext}`))) return true;
+    if (safeIsFile(join(repoPath, 'src', `middleware${ext}`))) return true;
+  }
+  return false;
+}
+
+function hasDynamicSegment(posixPath) {
+  return posixPath.split('/').some((segment) => {
+    // App Router names the directory (`blog/[slug]/page.tsx`); Pages Router
+    // names the file (`posts/[id].tsx`). Only strip a real code extension —
+    // `extname('[...path]')` returns '.path]'.
+    const ext = extname(segment);
+    const stem = CODE_EXTS.has(ext) ? basename(segment, ext) : segment;
+    return DYNAMIC_SEGMENT.test(stem);
+  });
+}
+
+function collectRouteGroups(appFiles) {
+  const groups = new Set();
+  for (const file of appFiles) {
+    for (const segment of file.path.split('/')) {
+      if (ROUTE_GROUP.test(segment)) groups.add(segment);
+    }
+  }
+  return [...groups].sort();
+}
+
+/**
+ * Count client and server components.
+ *
+ * The two counts have different denominators on purpose. A `'use client'`
+ * directive is explicit wherever it appears, so client components are counted
+ * across the whole source root. "Server component by default" is an App Router
+ * rule, so only files under the app directory count as server components —
+ * `next.config.js` and `lib/` helpers are neither.
+ */
+function classifyComponents(repoPath, appDir) {
+  const srcDir = join(repoPath, 'src');
+  const sourceRoot = safeIsDir(srcDir) ? srcDir : repoPath;
+  const appFull = appDir ? join(repoPath, appDir) : null;
+
+  // A root-level `app/` alongside `src/` sits outside the source root.
+  const roots = [sourceRoot];
+  if (appFull && !isInside(sourceRoot, appFull)) roots.push(appFull);
+
+  let client = 0;
+  let server = 0;
+
+  for (const root of roots) {
+    // Build output only masquerades as source at the source root; an `app/`
+    // root's own top-level names are URL segments.
+    walkSourceFiles(root, (full) => {
+      if (hasUseClientDirective(full)) client++;
+      else if (appFull && isInside(appFull, full)) server++;
+    }, 0, root === sourceRoot);
+  }
+
+  return { client, server };
+}
+
+function walkSourceFiles(dir, visit, depth = 0, rootSkip = true) {
+  if (depth > 12) return;
+  let entries;
+  try { entries = readdirSync(dir); } catch { return; }
+
+  for (const entry of entries) {
+    if (entry.startsWith('.')) continue;
+    if (ALWAYS_SKIP_DIRS.has(entry)) continue;
+    if (depth === 0 && rootSkip && ROOT_SKIP_DIRS.has(entry)) continue;
+
+    const full = join(dir, entry);
+    let stat;
+    try { stat = statSync(full); } catch { continue; }
+
+    if (stat.isDirectory()) {
+      walkSourceFiles(full, visit, depth + 1, rootSkip);
+      continue;
+    }
+
+    // Only regular files — this walker's visitor opens what it is handed,
+    // and opening a FIFO blocks.
+    if (!stat.isFile()) continue;
+    if (!CODE_EXTS.has(extname(entry))) continue;
+    visit(full);
+  }
+}
+
+function isInside(parent, child) {
+  return child === parent || child.startsWith(parent + sep);
+}
+
+function hasUseClientDirective(filePath) {
+  let fd;
+  try { fd = openSync(filePath, 'r'); } catch { return false; }
+
+  try {
+    const buf = Buffer.alloc(DIRECTIVE_HEAD_BYTES);
+    const read = readSync(fd, buf, 0, DIRECTIVE_HEAD_BYTES, 0);
+    const head = buf.toString('utf8', 0, read).replace(/^\uFEFF/, '');
+    return /^(['"])use client\1/.test(stripLeadingTrivia(head));
+  } catch {
+    return false;
+  } finally {
+    try { closeSync(fd); } catch { /* already gone */ }
+  }
+}
+
+/**
+ * Skip whitespace and comments so a directive behind a license header still
+ * counts. An unterminated comment means the directive is out of reach.
+ */
+function stripLeadingTrivia(text) {
+  let i = 0;
+  while (i < text.length) {
+    const ch = text[i];
+    if (ch === ' ' || ch === '\t' || ch === '\r' || ch === '\n') {
+      i++;
+      continue;
+    }
+    if (text.startsWith('//', i)) {
+      const nl = text.indexOf('\n', i);
+      if (nl === -1) return '';
+      i = nl + 1;
+      continue;
+    }
+    if (text.startsWith('/*', i)) {
+      const end = text.indexOf('*/', i + 2);
+      if (end === -1) return '';
+      i = end + 2;
+      continue;
+    }
+    break;
+  }
+  return text.slice(i);
 }

--- a/src/lib/frameworks/nextjs.js
+++ b/src/lib/frameworks/nextjs.js
@@ -321,12 +321,21 @@ function routerType(appDir, pagesDir) {
   return null;
 }
 
-function hasAppLayout(dir) {
+/**
+ * A root layout is mandatory, but it need not sit directly under `app/`.
+ * Multiple root layouts live one per route group (`app/(shop)/layout.tsx`),
+ * with nothing at the app root, so route groups are searched recursively.
+ */
+function hasAppLayout(dir, depth = 0) {
   if (!safeIsDir(dir)) return false;
   for (const ext of CODE_EXTS) {
     if (safeIsFile(join(dir, `layout${ext}`))) return true;
   }
-  return false;
+  if (depth >= 4) return false;
+
+  let entries;
+  try { entries = readdirSync(dir); } catch { return false; }
+  return entries.some(entry => ROUTE_GROUP.test(entry) && hasAppLayout(join(dir, entry), depth + 1));
 }
 
 function hasMiddleware(repoPath) {

--- a/src/lib/scanner.js
+++ b/src/lib/scanner.js
@@ -3,21 +3,25 @@ import { join, basename, extname } from 'path';
 import { SOURCE_EXTS } from './source-exts.js';
 import { relativePosix, toPosix } from './posix-path.js';
 import { detectCICD } from './cicd.js';
+import { probeNextjsArchitecture } from './frameworks/nextjs.js';
 
 /**
  * Scan a repository and return its tech stack, structure, and domains.
  * Fully deterministic — no LLM calls.
  */
 export function scanRepo(repoPath, { extraDomains } = {}) {
+  const frameworks = detectFrameworks(repoPath);
+
   const result = {
     path: repoPath,
     name: basename(repoPath),
     languages: detectLanguages(repoPath),
-    frameworks: detectFrameworks(repoPath),
+    frameworks,
     structure: detectStructure(repoPath),
     domains: detectDomains(repoPath),
     entryPoints: detectEntryPoints(repoPath),
     cicd: detectCICD(repoPath),
+    nextjs: probeNextjsArchitecture(repoPath, frameworks),
     hasClaudeConfig: existsSync(join(repoPath, '.claude')),
     hasClaudeMd: existsSync(join(repoPath, 'CLAUDE.md')),
     hasCodexConfig: existsSync(join(repoPath, '.codex')),

--- a/tests/scanner.test.js
+++ b/tests/scanner.test.js
@@ -490,4 +490,224 @@ describe('scanRepo', () => {
       expect(scanRepo(dir).hasClaudeMd).toBe(true);
     });
   });
+
+  describe('Next.js architecture probe', () => {
+    const NEXT_PKG = '{"name":"web","dependencies":{"next":"15.0.0","react":"19.0.0"}}';
+
+    it('detects App Router with route, API, and component counts', () => {
+      const dir = createFixture('next-app-router', {
+        'package.json': NEXT_PKG,
+        'app/layout.tsx': 'export default function L({ children }) { return children; }',
+        'app/page.tsx': 'export default function P() { return null; }',
+        'app/about/page.tsx': 'export default function A() { return null; }',
+        'app/api/health/route.ts': 'export function GET() {}',
+        'app/ui/button.tsx': "'use client'\nexport function Button() { return null; }",
+      });
+      const scan = scanRepo(dir);
+      expect(scan.nextjs).toMatchObject({
+        router: 'app',
+        appDir: 'app',
+        pagesDir: null,
+        routes: 2,
+        apiRoutes: 1,
+        dynamicRoutes: 0,
+        routeGroups: [],
+        clientComponents: 1,
+        middleware: false,
+      });
+      // layout, page, about/page, api/health/route — button.tsx is a client component
+      expect(scan.nextjs.serverComponents).toBe(4);
+    });
+
+    it('counts dynamic routes and route groups', () => {
+      const dir = createFixture('next-dynamic', {
+        'package.json': NEXT_PKG,
+        'app/layout.tsx': 'export default function L() {}',
+        'app/(marketing)/pricing/page.tsx': 'export default function P() {}',
+        'app/blog/[slug]/page.tsx': 'export default function P() {}',
+        'app/docs/[...path]/page.tsx': 'export default function P() {}',
+        'app/shop/[[...filters]]/page.tsx': 'export default function P() {}',
+      });
+      const scan = scanRepo(dir);
+      expect(scan.nextjs.routes).toBe(4);
+      expect(scan.nextjs.dynamicRoutes).toBe(3);
+      expect(scan.nextjs.routeGroups).toEqual(['(marketing)']);
+    });
+
+    it('detects Pages Router and excludes special files', () => {
+      const dir = createFixture('next-pages-router', {
+        'package.json': NEXT_PKG,
+        'pages/_app.tsx': 'export default function App() {}',
+        'pages/_document.tsx': 'export default function Doc() {}',
+        'pages/_error.tsx': 'export default function Err() {}',
+        'pages/index.tsx': 'export default function Home() {}',
+        'pages/about.tsx': 'export default function About() {}',
+        'pages/posts/[id].tsx': 'export default function Post() {}',
+        'pages/api/users.ts': 'export default function handler() {}',
+      });
+      const scan = scanRepo(dir);
+      expect(scan.nextjs).toMatchObject({
+        router: 'pages',
+        appDir: null,
+        pagesDir: 'pages',
+        routes: 3,
+        apiRoutes: 1,
+        dynamicRoutes: 1,
+        serverComponents: 0,
+      });
+    });
+
+    it('reports migration when both routers are present', () => {
+      const dir = createFixture('next-migrating', {
+        'package.json': NEXT_PKG,
+        'app/layout.tsx': 'export default function L() {}',
+        'app/page.tsx': 'export default function P() {}',
+        'pages/legacy.tsx': 'export default function Legacy() {}',
+        'pages/api/ping.ts': 'export default function h() {}',
+      });
+      const scan = scanRepo(dir);
+      expect(scan.nextjs).toMatchObject({
+        router: 'migrating',
+        appDir: 'app',
+        pagesDir: 'pages',
+        routes: 2,
+        apiRoutes: 1,
+      });
+    });
+
+    it('handles a src/ directory structure and middleware', () => {
+      const dir = createFixture('next-src-dir', {
+        'package.json': NEXT_PKG,
+        'src/app/layout.tsx': 'export default function L() {}',
+        'src/app/page.tsx': 'export default function P() {}',
+        'src/middleware.ts': 'export function middleware() {}',
+        'src/components/modal.tsx': '"use client";\nexport function Modal() {}',
+      });
+      const scan = scanRepo(dir);
+      expect(scan.nextjs).toMatchObject({
+        router: 'app',
+        appDir: 'src/app',
+        middleware: true,
+        clientComponents: 1,
+        serverComponents: 2,
+      });
+    });
+
+    it('recognises a use client directive behind leading comments', () => {
+      const dir = createFixture('next-directive-comments', {
+        'package.json': NEXT_PKG,
+        'app/layout.tsx': 'export default function L() {}',
+        'app/page.tsx': 'export default function P() {}',
+        'components/a.tsx': "// license header\n/* block */\n'use client'\nexport const A = 1;",
+        'components/b.tsx': "export const B = 1; // 'use client' mentioned in a comment\n",
+      });
+      const scan = scanRepo(dir);
+      expect(scan.nextjs.clientComponents).toBe(1);
+    });
+
+    it('normalises the repo path before comparing directories', () => {
+      const dir = createFixture('next-trailing-sep', {
+        'package.json': NEXT_PKG,
+        'app/layout.tsx': 'export default function L() {}',
+        'app/page.tsx': 'export default function P() {}',
+      });
+      // A trailing separator must not make the app directory look external to
+      // the source root — that walks it twice and doubles the counts.
+      const scan = scanRepo(dir + sep);
+      expect(scan.nextjs.serverComponents).toBe(2);
+      expect(scan.nextjs.routes).toBe(1);
+    });
+
+    it('excludes private app folders from routing', () => {
+      const dir = createFixture('next-private-folder', {
+        'package.json': NEXT_PKG,
+        'app/layout.tsx': 'export default function L() {}',
+        'app/page.tsx': 'export default function P() {}',
+        'app/_dev/page.tsx': 'export default function Scratch() {}',
+        'app/_dev/api/route.ts': 'export function GET() {}',
+      });
+      const scan = scanRepo(dir);
+      // `_dev` opts itself and its children out of routing.
+      expect(scan.nextjs.routes).toBe(1);
+      expect(scan.nextjs.apiRoutes).toBe(0);
+    });
+
+    it('treats Pages Router special stems as special only at the root', () => {
+      const dir = createFixture('next-nested-special', {
+        'package.json': NEXT_PKG,
+        'pages/_app.tsx': 'export default function App() {}',
+        'pages/index.tsx': 'export default function Home() {}',
+        'pages/docs/_error.tsx': 'export default function DocsError() {}',
+      });
+      const scan = scanRepo(dir);
+      // Only `pages/_app` is plumbing; `pages/docs/_error` is a real route.
+      expect(scan.nextjs.routes).toBe(2);
+    });
+
+    it('counts app routes whose segment matches a build-output name', () => {
+      const dir = createFixture('next-build-segment', {
+        'package.json': NEXT_PKG,
+        'app/layout.tsx': 'export default function L() {}',
+        'app/page.tsx': 'export default function P() {}',
+        'app/build/page.tsx': 'export default function BuildYours() {}',
+        'dist/app/page.js': 'module.exports = {}',
+      });
+      const scan = scanRepo(dir);
+      // `build` is a legitimate URL segment; only root-level build output is
+      // skipped, so the route counts as a server component too.
+      expect(scan.nextjs.routes).toBe(2);
+      expect(scan.nextjs.serverComponents).toBe(3);
+    });
+
+    it('counts build-named app routes when app sits beside src', () => {
+      const dir = createFixture('next-build-segment-src', {
+        'package.json': NEXT_PKG,
+        'app/layout.tsx': 'export default function L() {}',
+        'app/build/page.tsx': 'export default function BuildYours() {}',
+        'src/lib/util.ts': 'export const x = 1;',
+      });
+      const scan = scanRepo(dir);
+      // `app/` is its own walk root here, so `build` must not be taken for
+      // build output.
+      expect(scan.nextjs.routes).toBe(1);
+      expect(scan.nextjs.serverComponents).toBe(2);
+    });
+
+    it('counts a parallel route slot and its base page as one route', () => {
+      const dir = createFixture('next-parallel-slots', {
+        'package.json': NEXT_PKG,
+        'app/layout.tsx': 'export default function L({ children, modal }) {}',
+        'app/page.tsx': 'export default function P() {}',
+        'app/photo/page.tsx': 'export default function Photo() {}',
+        'app/@modal/photo/page.tsx': 'export default function Modal() {}',
+        'app/@modal/default.tsx': 'export default function D() {}',
+      });
+      const scan = scanRepo(dir);
+      // `@modal` never reaches the URL, so both photo pages serve `/photo`.
+      expect(scan.nextjs.routes).toBe(2);
+      // Every file under app/ is still a server component.
+      expect(scan.nextjs.serverComponents).toBe(5);
+    });
+
+    it('counts a slot-only route once', () => {
+      const dir = createFixture('next-slot-only', {
+        'package.json': NEXT_PKG,
+        'app/layout.tsx': 'export default function L() {}',
+        'app/@team/settings/[id]/page.tsx': 'export default function S() {}',
+        'app/@team/api/hook/route.ts': 'export function GET() {}',
+      });
+      const scan = scanRepo(dir);
+      expect(scan.nextjs.routes).toBe(1);
+      expect(scan.nextjs.dynamicRoutes).toBe(1);
+      expect(scan.nextjs.apiRoutes).toBe(1);
+    });
+
+    it('returns null for repos that are not Next.js', () => {
+      const dir = createFixture('next-absent', {
+        'package.json': '{"name":"api","dependencies":{"express":"4.19.0"}}',
+        'app/page.tsx': 'export default function P() {}',
+      });
+      expect(scanRepo(dir).nextjs).toBeNull();
+    });
+  });
 });

--- a/tests/scanner.test.js
+++ b/tests/scanner.test.js
@@ -689,6 +689,24 @@ describe('scanRepo', () => {
       expect(scan.nextjs.serverComponents).toBe(5);
     });
 
+    it('detects the app directory when the only root layout is in a route group', () => {
+      const dir = createFixture('next-group-root-layout', {
+        'package.json': NEXT_PKG,
+        'app/(marketing)/layout.tsx': 'export default function L({ children }) { return children; }',
+        'app/(marketing)/page.tsx': 'export default function P() {}',
+        'app/(shop)/layout.tsx': 'export default function L({ children }) { return children; }',
+        'app/(shop)/cart/page.tsx': 'export default function C() {}',
+      });
+      const scan = scanRepo(dir);
+      // Multiple root layouts: nothing sits directly under `app/`.
+      expect(scan.nextjs).toMatchObject({
+        router: 'app',
+        appDir: 'app',
+        routes: 2,
+        routeGroups: ['(marketing)', '(shop)'],
+      });
+    });
+
     it('counts a slot-only route once', () => {
       const dir = createFixture('next-slot-only', {
         'package.json': NEXT_PKG,


### PR DESCRIPTION
**Problem**

`aspens scan` could tell you a repo uses Next.js and nothing else. Two Next.js projects can be built in completely different ways: App Router with server components, or Pages Router with a `pages/api` tree. A generated skill had no way to tell them apart, so it could not say "App Router, 12 routes, 3 client components".

**Fix**

**New probe.**

- `src/lib/frameworks/nextjs.js` exports `probeNextjsArchitecture(repoPath, frameworks)`, called from `scanRepo()` and exposed as `scanResult.nextjs`.
- Returns `null` when Next.js is not among the detected frameworks, so nothing changes for other repos.
- It reads file contents, which no other part of the scanner does. Reads are bounded to the first 1KB of a source file and only look for a `'use client'` directive prologue.

The probe lives beside the existing framework detectors rather than in `scanner.js` as the issue suggested. That module already owns the directory candidates, code extensions, and walker this needed.

**What it reports.**

- Router in use: `app`, `pages`, or `both` for a repo mid-migration.
- Route count, API route count, dynamic route count.
- Route groups, listed by name.
- Client and server component counts, split on the `'use client'` directive.
- Whether middleware exists.

Root-level and `src/` layouts both work.

**Routing rules honoured.**

- Private folders (`_name`) opt out of routing and still count as components.
- `_app`, `_document`, and `_error` are plumbing at the Pages Router root only. A page of the same name deeper in the tree is a real route.
- Parallel route slots (`@modal`) and route groups (`(shop)`) never reach the URL, so App Router files are deduped by the URL they serve. `app/@modal/photo/page.tsx` and `app/photo/page.tsx` are one route.
- Dynamic segments are named by directory in the App Router and by filename in the Pages Router.
- Build output names (`dist`, `build`, `out`, `coverage`, `public`) are skipped at a source root only. Deeper down they are ordinary URL segments, so `app/build/page.tsx` counts as a route.

Known imprecision: intercepting routes (`(.)photo`) count separately from the page they intercept. Resolving `(..)` levels needs a real segment-tree walk, which is disproportionate for how rarely the pattern appears.

**Surfacing.**

- `aspens scan` prints a `Next.js:` line, for example `App Router, 12 routes, 3 dynamic, 4 API routes, groups: (marketing), 2 client / 18 server components, middleware`.
- `buildContext` and `buildBaseContext` already serialize the whole scan result into prompt context, so only the chunked-mode summary in `buildDomainContext` needed an explicit line.

**Tests**

New `Next.js architecture probe` block in `tests/scanner.test.js`, on the existing fixture helper:

- App Router with route, API, and component counts
- Pages Router, with special files excluded
- both routers present, reported as a migration
- a `src/` layout, including middleware
- dynamic routes and route groups
- a `'use client'` directive behind leading comments
- a repo path that needs normalising before directory comparison
- private app folders excluded from routing
- Pages Router special stems treated as special at the root only
- app routes whose segment is named like a build output directory, both with and without a `src/` root
- a parallel route slot and its base page counted as one route, and a slot-only route counted once
- `null` for a repo that is not Next.js

`npm test`: 466 passed, 1 skipped, 33 files. Also spot-checked `node bin/cli.js scan` against synthetic App Router, Pages Router, and `src/` fixtures.

Closes #8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Next.js architecture detection to repository scans.
  - Scan results now identify App Router, Pages Router, or migration setups.
  - Reports include route counts, API routes, dynamic routes, route groups, client/server components, and middleware status.
  - Next.js summaries are shown in scan output and repository context headers.
  - Improved handling of `src` layouts, private folders, parallel route slots, and build-generated route names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->